### PR TITLE
removed PDF build and deprecated RTD system packages build option

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -16,8 +16,7 @@ sphinx:
    configuration: docs/conf.py
 
 # If using Sphinx, optionally build your docs in additional formats such as PDF
-formats:
-   - pdf
+# formats:
 
 # Optionally declare the Python requirements required to build your docs
 python:
@@ -25,4 +24,3 @@ python:
     - requirements: docs/requirements.txt
     - method: pip
       path: .
-  system_packages: true


### PR DESCRIPTION
The "system packages" build option is being deprecated at the end of the month and all package requirements are already defined in setup.py. I also turned off PDF builds, which can be very slow and encourage people to use outdated documentation. 