### PR TITLE
removed deprecated system_packages flag in RTD config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -25,4 +25,3 @@ python:
     - requirements: docs/requirements.txt
     - method: pip
       path: .
-  system_packages: true


### PR DESCRIPTION
Read the Docs is deprecating this config and all required packages must be installed through setup.py or requirements.txt. 