### PR TITLE
RTD doc build updates, fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,7 +83,7 @@ instance/
 # Sphinx documentation
 docs/_build/
 docs/modules.rst
-docs/hpvsim.*.rst
+docs/hpvsim*.rst
 
 # PyBuilder
 target/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -57,6 +57,25 @@ extensions = [
     'nbsphinx',
     'IPython.sphinxext.ipython_console_highlighting',  # Temporary fix for https://github.com/spatialaudio/nbsphinx/issues/687
     'sphinx_search.extension', # search across multiple docsets in domain
+    'myst_parser', # source files written in MD or RST
+]
+
+myst_enable_extensions = [
+    "amsmath",
+    "attrs_inline",
+    "colon_fence",
+    "deflist",
+    "dollarmath",
+    "fieldlist",
+    "html_admonition",
+    "html_image",
+    "inv_link",
+    "linkify",
+    "replacements",
+    "smartquotes",
+    "strikethrough",
+    "substitution",
+    "tasklist",
 ]
 
 autodoc_default_options = {
@@ -132,7 +151,12 @@ html_favicon = "images/favicon.ico"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
+
 html_static_path = ['_static']
+
+html_css_files = ['theme_overrides.css']
+
+html_js_files = ['show_block_by_os.js'] 
 
 html_context = {
     'rtd_url': 'https://docs.idmod.org/projects/hpvsim/en/latest',

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -55,7 +55,8 @@ extensions = [
     'sphinx.ext.todo',
     'sphinx.ext.viewcode',  # Add a link to the Python source code for classes, functions etc.
     'nbsphinx',
-    'IPython.sphinxext.ipython_console_highlighting'  # Temporary fix for https://github.com/spatialaudio/nbsphinx/issues/687
+    'IPython.sphinxext.ipython_console_highlighting',  # Temporary fix for https://github.com/spatialaudio/nbsphinx/issues/687
+    'sphinx_search.extension', # search across multiple docsets in domain
 ]
 
 autodoc_default_options = {
@@ -158,6 +159,21 @@ html_show_sphinx = False
 # contain a <link> tag referring to it.  The value of this option must be the
 # base URL from which the finished HTML is served.
 html_use_opensearch = 'docs.idmod.org/projects/hpvsim/en/latest'
+
+# -- RTD Sphinx search for searching across the entire domain, default child -------------
+
+if os.environ.get('READTHEDOCS') == 'True':
+
+    search_project_parent = "institute-for-disease-modeling-idm"
+    search_project = os.environ["READTHEDOCS_PROJECT"]
+    search_version = os.environ["READTHEDOCS_VERSION"]
+
+    rtd_sphinx_search_default_filter = f"subprojects:{search_project}/{search_version}"
+
+    rtd_sphinx_search_filters = {
+        "Search this project": f"project:{search_project}/{search_version}",
+        "Search all IDM docs": f"subprojects:{search_project_parent}/{search_version}",
+    }
 
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'HPVsim'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -69,7 +69,6 @@ myst_enable_extensions = [
     "fieldlist",
     "html_admonition",
     "html_image",
-    "inv_link",
     "linkify",
     "replacements",
     "smartquotes",

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,3 +8,6 @@ pandoc
 pypandoc
 optuna
 seaborn
+myst-parser
+readthedocs-sphinx-search
+jupyterlab


### PR DESCRIPTION
Commit comments link to the tickets in the idm-content repo for Sphinx/Read the Docs infrastructure. Removed deprecated doc build config options, added improved search and myst extension to write source files in RST or Markdown. Updated packages used to build docs.