### PR TITLE
v2.2.7: fix cancer treatment results always blank

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ that may result in differences in model output, or are required in order
 to run an old parameter set with the current version, are flagged with
 the term "Regression information".
 
+## Version 2.2.7 (2026-04-22)
+
+- Fix cancer treatment results always being blank: `BaseTreatment.check_eligibility` was excluding cancer patients (preventing radiation from running), `BaseTreatment.apply` was writing to CIN fields for cancer treatment, and `cum_cancer_treated` cumsum used the wrong source array
+- *Github info* PR [92](https://github.com/starsimhub/hpvsim/pull/92), issue [91](https://github.com/starsimhub/hpvsim/issues/91)
+
 ## Version 2.2.6 (2026-04-17)
 
 - Reconcile different copies of repository

--- a/hpvsim/interventions.py
+++ b/hpvsim/interventions.py
@@ -967,6 +967,7 @@ class BaseTreatment(Intervention):
         self.eligibility = eligibility
         self._parse_product(product)
         self.age_range = age_range or [0,99] # By default, no restrictions on treatment age
+        self.treat_cancer = isinstance(self.product, radiation)
 
 
     def _parse_product(self, product):
@@ -998,8 +999,11 @@ class BaseTreatment(Intervention):
         females         = sim.people.is_female
         in_age_range    = (sim.people.age >= self.age_range[0]) * (sim.people.age <= self.age_range[1])
         alive           = sim.people.alive
-        nocancer        = ~sim.people.cancerous.any(axis=0)
-        conditions      = (females * in_age_range * alive * nocancer)
+        if self.treat_cancer:
+            cancer_cond = sim.people.cancerous.any(axis=0)
+        else:
+            cancer_cond = ~sim.people.cancerous.any(axis=0)
+        conditions      = (females * in_age_range * alive * cancer_cond)
         return conditions
 
     def get_accept_inds(self, sim):
@@ -1030,17 +1034,16 @@ class BaseTreatment(Intervention):
         treat_inds = hpu.itruei(still_eligible, treat_candidates)
 
         # Store treatment and dates
-        new_treat_inds = hpu.ifalsei(sim.people.cin_treated, treat_inds)  # Figure out people who are getting radiation for the first time
-        sim.people.cin_treated[treat_inds] = True
-        sim.people.cin_treatments[treat_inds] += 1
-        sim.people.date_cin_treated[treat_inds] = sim.t
-
-        # Store results
         idx = int(sim.t / sim.resfreq)
-        n_new_cin_treatments = sim.people.scale_flows(treat_inds)  # Scale
-        n_new_people = sim.people.scale_flows(new_treat_inds)  # Scale
-        sim.results['new_cin_treated'][idx] += n_new_people
-        sim.results['new_cin_treatments'][idx] += n_new_cin_treatments
+        if not self.treat_cancer:
+            new_treat_inds = hpu.ifalsei(sim.people.cin_treated, treat_inds)
+            sim.people.cin_treated[treat_inds] = True
+            sim.people.cin_treatments[treat_inds] += 1
+            sim.people.date_cin_treated[treat_inds] = sim.t
+            n_new_cin_treatments = sim.people.scale_flows(treat_inds)
+            n_new_people = sim.people.scale_flows(new_treat_inds)
+            sim.results['new_cin_treated'][idx] += n_new_people
+            sim.results['new_cin_treatments'][idx] += n_new_cin_treatments
 
         # Administer treatment and store products used
         self.outcomes = self.product.administer(sim, treat_inds)

--- a/hpvsim/sim.py
+++ b/hpvsim/sim.py
@@ -1134,7 +1134,7 @@ class Sim(hpb.BaseSim):
         self.results['cum_cin_treatments'][:] = np.cumsum(self.results['new_cin_treatments'][:], axis=0)
         self.results['cum_cin_treated'][:] = np.cumsum(self.results['new_cin_treated'][:], axis=0)
         self.results['cum_cancer_treatments'][:] = np.cumsum(self.results['new_cancer_treatments'][:], axis=0)
-        self.results['cum_cancer_treated'][:] = np.cumsum(self.results['new_cancer_treatments'][:], axis=0)
+        self.results['cum_cancer_treated'][:] = np.cumsum(self.results['new_cancer_treated'][:], axis=0)
 
         return
     

--- a/hpvsim/version.py
+++ b/hpvsim/version.py
@@ -4,6 +4,6 @@ Version and license information.
 
 __all__ = ['__version__', '__versiondate__', '__license__']
 
-__version__ = '2.2.6'
-__versiondate__ = '2026-04-17'
+__version__ = '2.2.7'
+__versiondate__ = '2026-04-22'
 __license__ = f'HPVsim {__version__} ({__versiondate__}) — © 2023-2026 by the Gates Foundation'

--- a/tests/test_interventions.py
+++ b/tests/test_interventions.py
@@ -572,6 +572,63 @@ def test_cytology():
     return scens
 
 
+def test_cancer_treatment():
+    sc.heading('Test that cancer treatment results are non-zero (issue #91)')
+
+    screen_eligible = lambda sim: np.isnan(sim.people.date_screened) | (sim.t > (sim.people.date_screened + 5 / sim['dt']))
+    screen = hpv.routine_screening(
+        product='hpv',
+        prob=1.0,
+        eligibility=screen_eligible,
+        age_range=[0, 100],
+        start_year=2010,
+        label='screen',
+    )
+
+    screen_positive = lambda sim: sim.get_intervention('screen').outcomes['positive']
+    assign_treatment = hpv.routine_triage(
+        prob=1.0,
+        product='tx_assigner',
+        eligibility=screen_positive,
+        label='tx assigner',
+    )
+
+    radiation_eligible = lambda sim: sim.get_intervention('tx assigner').outcomes['radiation']
+    radiation = hpv.treat_num(
+        prob=1.0,
+        product=hpv.radiation(),
+        eligibility=radiation_eligible,
+        label='radiation',
+    )
+
+    ablation_eligible = lambda sim: sim.get_intervention('tx assigner').outcomes['ablation']
+    ablation = hpv.treat_num(prob=1.0, product='ablation', eligibility=ablation_eligible, label='ablation')
+
+    excision_eligible = lambda sim: sim.get_intervention('tx assigner').outcomes['excision']
+    excision = hpv.treat_num(prob=1.0, product='excision', eligibility=excision_eligible, label='excision')
+
+    interventions = [screen, assign_treatment, ablation, excision, radiation]
+    for intv in interventions: intv.do_plot = False
+
+    sim = hpv.Sim(pars=base_pars, interventions=interventions)
+    sim.run(verbose=0)
+
+    cum_cancer_tx   = sim.results['cum_cancer_treatments'][-1]
+    cum_cancer_txd  = sim.results['cum_cancer_treated'][-1]
+    cum_cin_tx      = sim.results['cum_cin_treatments'][-1]
+
+    print(f'Cumulative cancer treatments:      {cum_cancer_tx:.0f}')
+    print(f'Cumulative people treated (cancer): {cum_cancer_txd:.0f}')
+    print(f'Cumulative CIN treatments:          {cum_cin_tx:.0f}')
+
+    assert cum_cancer_tx  > 0, 'cum_cancer_treatments is zero — cancer treatment not being recorded'
+    assert cum_cancer_txd > 0, 'cum_cancer_treated is zero — cancer treatment not being recorded'
+    assert cum_cancer_txd <= cum_cancer_tx, 'people treated cannot exceed treatment events'
+    assert cum_cin_tx     > 0, 'CIN treatments broken by cancer-treatment fix'
+
+    return sim
+
+
 #%% Run as a script
 if __name__ == '__main__':
 
@@ -582,6 +639,7 @@ if __name__ == '__main__':
     sim1 = test_all_interventions(do_plot=do_plot)
     sim2 = test_txvx_noscreen()
     sim3 = test_screening()
+    sim4 = test_cancer_treatment()
     scens0 = test_vx_effect()
     scens1 = test_cytology()
 


### PR DESCRIPTION
## Summary

- `BaseTreatment.check_eligibility` required `~cancerous`, silently excluding all cancer patients before `radiation.administer()` could run — results were always zero
- `BaseTreatment.apply` unconditionally wrote to `cin_treated`/`cin_treatments` fields even for cancer treatment (radiation now handled via `self.treat_cancer` flag)
- `cum_cancer_treated` cumsum was pulling from `new_cancer_treatments` instead of `new_cancer_treated`

Closes #91

## Test plan

- [ ] `pytest tests/test_interventions.py` — all 7 tests pass
- [ ] New `test_cancer_treatment` asserts `cum_cancer_treatments > 0`, `cum_cancer_treated > 0`, people treated ≤ treatment events, and CIN results unaffected