### PR TITLE
M07 multisim

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # HPVsim-generated files
 *.obj
+*.png
 files/
 
 # Quarto

--- a/MIGRATION_PLAN.md
+++ b/MIGRATION_PLAN.md
@@ -79,7 +79,8 @@ Each milestone produces a user-visible demo and must meet its acceptance test be
 | M4: Calibration loop | 🟡 In progress | branch `m04-calibration-loop` |
 | M5 | 🟡 Implementation complete; PR not yet opened | branch `m05-vaccination-scenarios` |
 | M6: Test-and-treat cascade | 🟡 In progress | branch `m06-test-and-treat-cascade` |
-| M7–M10 | ⬜ Not started | — |
+| M7: MultiSim and scenarios | 🟡 In progress | branch `m07-multisim` |
+| M8–M10 | ⬜ Not started | — |
 
 ### M0: Foundation
 
@@ -290,10 +291,12 @@ campaign anchor), and the rationale for the |z| < 5 gate.
 
 **Sub-tasks:**
 - Verify `ss.MultiSim` works with `hpv.Sim` (multi-seed runs, result aggregation, median + quantiles).
-- Port the `Scenarios` class for parameter sweeps and intervention comparisons.
-- Port the `Sweep` class for systematic parameter variation.
-- Verify `ss.parallel()` works with proper random-seed handling.
-- Re-run M1–M6 acceptance tests under proper uncertainty quantification (overlap intervals, not deterministic-seed equality).
+- Verify `ss.parallel()` works with proper random-seed handling (same-seed reproducibility, copy_inputs semantics, inplace semantics).
+- Retrofit M01 and M02 acceptance tests onto multi-seed z-score parity gates matching the M03 standard (`|z| < 3` over 30 v3 seeds vs 30 v2 seeds). M03 and M05 already pass under multi-seed gates; M04 (calibration) and M06 (screen-and-treat) own their own UQ as part of their milestone scopes.
+- Add a shared `parity_gate()` helper in `tests/regression/parity.py` consumed by the new M01/M02 tests. Refactoring M03/M05 tests onto the helper is tracked as a post-merge follow-up.
+- Demo: `examples/m07_uq_sweep.py` — 4 × 20 (coverage × seed) routine-vx sweep on the M05 Nigeria anchor, with median + 10/90 quantile cancer-incidence-by-age plot. Smoke variant at `tests/test_m07_demo_smoke.py`.
+- Rewrite `docs/tutorials/tut_running.qmd`'s v2 `Scenarios` section onto Starsim-native `make_sim(seed, scenario)` + `ss.parallel` / `sc.parallelize` pattern.
+- **Dropped from M07 scope:** no `hpv.Scenarios` or `hpv.Sweep` shim; users use Starsim-native APIs directly. Validation repos (`hpvsim_methods_manuscript`, etc.) drop `hpv.Scenarios` imports as a separate post-M07 PR per repo, coordinated with Robyn per RACI.
 
 ### M8: HIV–HPV co-infection
 

--- a/docs/superpowers/plans/2026-05-27-m07-multisim.md
+++ b/docs/superpowers/plans/2026-05-27-m07-multisim.md
@@ -1,0 +1,1617 @@
+# M07: MultiSim and Scenarios — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `hpv.Sim` first-class with Starsim's multi-sim machinery — verify `ss.MultiSim`/`ss.parallel` work, retrofit M01/M02 acceptance tests to multi-seed z-score parity gates, ship a vx-coverage sweep demo, and rewrite the v2-`Scenarios` tutorial onto Starsim-native patterns. Ships ZERO new production code under `hpvsim/`.
+
+**Architecture:** All deliverables live under `tests/`, `examples/`, and `docs/`. No new `hpvsim/` modules; no re-exports of `ss.MultiSim`/`ss.parallel` from the `hpv` namespace. The user uses Starsim's API directly. The two new parity tests mirror `tests/test_m03_short_summary_parity.py`. The demo mirrors the documented Starsim `make_sim(seed, scenario)` + `ss.parallel` pattern.
+
+**Tech Stack:** Python 3.10+, Starsim 3.3.4 (`ss.MultiSim`, `ss.parallel`), Sciris (`sc.parallelize`), pytest, hpvsim v3 (current branch).
+
+**Spec:** [`docs/superpowers/specs/2026-05-27-m07-multisim-design.md`](../specs/2026-05-27-m07-multisim-design.md)
+
+**Branch:** all commits land on `m07-multisim`. PR targets `v3.0-dev` after `m05-vaccination-scenarios` merges (M07's demo depends on M05). If implementation finishes before M05 lands, hold PR in draft.
+
+---
+
+## File Structure
+
+| Path | Action | Purpose |
+|---|---|---|
+| `tests/regression/parity.py` | NEW | Shared `parity_gate()` helper |
+| `tests/regression/short_summary_m01.py` | NEW | M01 transmission-only summary builder |
+| `tests/regression/anchor_m01.py` | NEW | M01 anchor PARS + `run_and_summarize()` |
+| `tests/regression/anchor_m02.py` | NEW | M02 anchor PARS + `run_and_summarize()` |
+| `tests/regression/multi_seed_v2.py` | EDIT | Add `--anchor m01|m02|m03_4genotype` flag |
+| `tests/regression/baseline_v23.py` | EDIT | Add M01 anchor PARS for v2 baseline regen |
+| `tests/regression/README.md` | EDIT (or NEW) | Document new anchors + baseline regen |
+| `tests/test_m07_multisim.py` | NEW | Verify `ss.MultiSim` with `hpv.Sim` |
+| `tests/test_m07_parallel.py` | NEW | Verify `ss.parallel` + RNG semantics |
+| `tests/test_m07_demo_smoke.py` | NEW | Tiny smoke variant of demo |
+| `tests/test_m01_short_summary_parity.py` | NEW | M01 30-seed z-score gate |
+| `tests/test_m02_short_summary_parity.py` | NEW | M02 30-seed z-score gate |
+| `examples/m07_uq_sweep.py` | NEW | 4×20 vx-coverage sweep demo |
+| `docs/tutorials/tut_running.qmd` | EDIT | Replace v2 `Scenarios` section |
+| `MIGRATION_PLAN.md` | EDIT | M07 sub-task list realignment |
+
+---
+
+## Task 1: Shared parity_gate helper
+
+**Files:**
+- Create: `tests/regression/parity.py`
+- Test: `tests/regression/test_parity_helper.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/regression/test_parity_helper.py`:
+
+```python
+"""Unit tests for the shared parity_gate helper."""
+import math
+import pytest
+
+from tests.regression.parity import parity_gate
+
+
+def _row(seed, **metrics):
+    return {'_seed': seed, **metrics}
+
+
+def test_parity_gate_pass_means_overlap():
+    v2 = [_row(s, m=10.0 + 0.1 * s) for s in range(5)]
+    v3 = [_row(s, m=10.0 + 0.1 * s) for s in range(5)]
+    failures = parity_gate(v3, v2, z_threshold=3.0)
+    assert failures == []
+
+
+def test_parity_gate_fail_large_drift():
+    v2 = [_row(s, m=10.0 + 0.1 * s) for s in range(10)]
+    v3 = [_row(s, m=100.0 + 0.1 * s) for s in range(10)]
+    failures = parity_gate(v3, v2, z_threshold=3.0)
+    assert len(failures) == 1
+    name, z = failures[0]
+    assert name == 'm'
+    assert abs(z) > 3.0
+
+
+def test_parity_gate_skip_keys_ignored():
+    v2 = [_row(s, m=10.0, _total_pop=1e6) for s in range(5)]
+    v3 = [_row(s, m=10.0, _total_pop=2e6) for s in range(5)]
+    failures = parity_gate(v3, v2, z_threshold=3.0,
+                           skip_keys=frozenset({'_total_pop'}))
+    assert failures == []
+
+
+def test_parity_gate_degenerate_distributions_exact_match_passes():
+    v2 = [_row(s, m=10.0) for s in range(5)]
+    v3 = [_row(s, m=10.0) for s in range(5)]
+    failures = parity_gate(v3, v2, z_threshold=3.0)
+    assert failures == []
+
+
+def test_parity_gate_degenerate_distributions_mismatch_fails():
+    v2 = [_row(s, m=10.0) for s in range(5)]
+    v3 = [_row(s, m=11.0) for s in range(5)]
+    failures = parity_gate(v3, v2, z_threshold=3.0)
+    assert len(failures) == 1
+    assert failures[0][0] == 'm'
+    assert math.isinf(failures[0][1])
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+python -m pytest tests/regression/test_parity_helper.py -v
+```
+
+Expected: ImportError or ModuleNotFoundError on `tests.regression.parity`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `tests/regression/parity.py`:
+
+```python
+"""Shared parity-gate helper for multi-seed v3-vs-v2 metric comparison.
+
+The z-score formula is
+
+    z = (v3_mean - v2_mean) / sqrt(v2_SE^2 + v3_SE^2)
+
+where SE is the standard error of the mean across seeds (std with ddof=1
+divided by sqrt(n)). A metric fails when |z| >= z_threshold.
+
+Per-seed rows are dicts of {metric_name: value}. Non-metric bookkeeping
+keys (e.g. _seed, _total_pop) should be passed via skip_keys.
+"""
+import math
+
+import numpy as np
+
+
+def _mean_se(rows, key):
+    vals = np.array([float(r[key]) for r in rows if key in r], dtype=float)
+    if vals.size == 0:
+        return None
+    mean = float(vals.mean())
+    se = float(vals.std(ddof=1) / math.sqrt(vals.size)) if vals.size > 1 else 0.0
+    return mean, se
+
+
+def parity_gate(v3_seeds, v2_seeds, z_threshold=3.0, skip_keys=frozenset()):
+    """Return [(metric_name, z)] for metrics exceeding |z| >= z_threshold.
+
+    Args:
+        v3_seeds: list of per-seed summary dicts from the v3 run.
+        v2_seeds: list of per-seed summary dicts from the v2 baseline.
+        z_threshold: failure threshold; metrics with |z| >= threshold fail.
+        skip_keys: metric names to ignore (bookkeeping fields).
+
+    Two degenerate-distribution policies:
+      - both v2 and v3 have zero spread AND exactly equal means → pass.
+      - both have zero spread AND unequal means → fail with z=inf.
+    """
+    metric_keys = sorted((set(v2_seeds[0]) & set(v3_seeds[0])) - skip_keys)
+    failures = []
+    for key in metric_keys:
+        v2_stats = _mean_se(v2_seeds, key)
+        v3_stats = _mean_se(v3_seeds, key)
+        if v2_stats is None or v3_stats is None:
+            continue
+        v2_mean, v2_se = v2_stats
+        v3_mean, v3_se = v3_stats
+        se_combo = math.sqrt(v2_se ** 2 + v3_se ** 2)
+        if se_combo == 0:
+            if v2_mean != v3_mean:
+                failures.append((key, float('inf')))
+            continue
+        z = (v3_mean - v2_mean) / se_combo
+        if abs(z) >= z_threshold:
+            failures.append((key, z))
+    return failures
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+python -m pytest tests/regression/test_parity_helper.py -v
+```
+
+Expected: 5 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/regression/parity.py tests/regression/test_parity_helper.py
+git commit -m "M07: add parity_gate() helper for multi-seed z-score metric comparison"
+```
+
+---
+
+## Task 2: ss.MultiSim verification tests
+
+**Files:**
+- Create: `tests/test_m07_multisim.py`
+
+- [ ] **Step 1: Write the test file (all four tests at once)**
+
+Tests cover: `n_runs` distinctness, median reduction shape, mean reduction shape, label propagation. Each test uses a tiny sim to stay fast (<5 s).
+
+```python
+"""Verification tests: ss.MultiSim works with hpv.Sim.
+
+These tests confirm Starsim's MultiSim machinery composes correctly with
+hpv.Sim. They are NOT parity gates against v2 — they pin down behavior
+hpvsim depends on so future Starsim upgrades that change the contract
+break here loudly.
+
+Tiny n_agents and short dur keep each test under ~5 s.
+"""
+import numpy as np
+import pytest
+
+import sciris as sc
+import starsim as ss
+import hpvsim as hpv
+
+
+def _tiny_sim(rand_seed=0, label=None):
+    return hpv.Sim(
+        n_agents=300,
+        location='nigeria',
+        genotypes=[16],
+        start=2000,
+        stop=2003,
+        dt=0.25,
+        rand_seed=rand_seed,
+        verbose=0,
+        label=label,
+    )
+
+
+def test_multisim_n_runs_distinct_seeds():
+    """ss.MultiSim(sim, n_runs=N).run() produces N sims with distinct seeds."""
+    sim = _tiny_sim(rand_seed=0)
+    msim = ss.MultiSim(sim, n_runs=4).run(verbose=0)
+    assert len(msim.sims) == 4
+    seeds = [int(s.pars.rand_seed) for s in msim.sims]
+    assert len(set(seeds)) == 4, f'Expected 4 distinct seeds, got {seeds}'
+    # Every run produced finite total infections.
+    for s in msim.sims:
+        cum_inf = float(s.results.hpv16.cum_infections[-1])
+        assert np.isfinite(cum_inf)
+        assert cum_inf >= 0
+
+
+def test_multisim_median_reduce_shape_and_nonneg():
+    """msim.median() exposes median + 10/90 quantile arrays; non-negative for counts."""
+    sim = _tiny_sim(rand_seed=0)
+    msim = ss.MultiSim(sim, n_runs=5).run(verbose=0)
+    pre_len = len(np.asarray(msim.sims[0].results.hpv16.cum_infections))
+    msim.median()
+    # After reduce, msim exposes a single aggregate result with the same
+    # time-axis length as each underlying sim.
+    reduced = np.asarray(msim.results.hpv16.cum_infections)
+    assert reduced.shape == (pre_len,)
+    assert np.all(reduced >= 0), 'cum_infections must be non-negative post-median'
+
+
+def test_multisim_mean_reduce_smoke():
+    """msim.mean() functions (smoke test). Don't use on bounded metrics in production."""
+    sim = _tiny_sim(rand_seed=0)
+    msim = ss.MultiSim(sim, n_runs=5).run(verbose=0)
+    msim.mean()
+    reduced = np.asarray(msim.results.hpv16.cum_infections)
+    assert reduced.shape[0] > 0
+    assert np.isfinite(reduced).all()
+
+
+def test_multisim_labels_propagate():
+    """Labels on input sims survive to msim.sims[i].label after run()."""
+    sims = [_tiny_sim(rand_seed=s, label=f'rep-{s}') for s in range(3)]
+    msim = ss.MultiSim(sims).run(verbose=0)
+    assert [s.label for s in msim.sims] == ['rep-0', 'rep-1', 'rep-2']
+```
+
+- [ ] **Step 2: Run the tests**
+
+```bash
+python -m pytest tests/test_m07_multisim.py -v
+```
+
+Expected: 4 passed, total runtime < 60 s.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_m07_multisim.py
+git commit -m "M07: verify ss.MultiSim composes with hpv.Sim (n_runs/median/mean/labels)"
+```
+
+---
+
+## Task 3: ss.parallel + RNG semantics tests
+
+**Files:**
+- Create: `tests/test_m07_parallel.py`
+
+- [ ] **Step 1: Write the test file (all four tests at once)**
+
+```python
+"""Verification tests: ss.parallel + hpv.Sim with correct RNG semantics.
+
+Locks in four properties hpvsim relies on:
+  1. Same rand_seed → identical short summaries (CRN guarantee).
+  2. Different rand_seeds → plausibly distinct, plausibly distributed results.
+  3. ss.parallel(inplace=True) (default) populates the original sims.
+  4. copy_inputs=True (sim default) ensures shared module references are
+     independent per sim post-construction — the [[feedback_sim_input_copy]]
+     discipline reified as a regression test. Module state must be accessed
+     via sim.interventions[...] after construction, not via the original
+     reference.
+"""
+import numpy as np
+import pytest
+
+import sciris as sc
+import starsim as ss
+import hpvsim as hpv
+
+
+def _tiny_sim(rand_seed=0, label=None):
+    return hpv.Sim(
+        n_agents=300,
+        location='nigeria',
+        genotypes=[16],
+        start=2000,
+        stop=2003,
+        dt=0.25,
+        rand_seed=rand_seed,
+        verbose=0,
+        label=label,
+    )
+
+
+def _short_summary(sim):
+    """Tiny summary suitable for bit-equality assertions."""
+    return {
+        'cum_inf': float(sim.results.hpv16.cum_infections[-1]),
+        'n_alive': float(sim.results['n_alive'][-1]),
+    }
+
+
+def test_parallel_seed_reproducibility():
+    """Same rand_seed → identical short summary across two ss.parallel calls."""
+    s1 = _tiny_sim(rand_seed=42, label='a')
+    s2 = _tiny_sim(rand_seed=42, label='b')
+    ss.parallel(s1, s2, verbose=0)
+    assert _short_summary(s1) == _short_summary(s2)
+
+
+def test_parallel_seed_separation():
+    """Different rand_seeds → different short summaries (sanity)."""
+    s1 = _tiny_sim(rand_seed=0, label='a')
+    s2 = _tiny_sim(rand_seed=1, label='b')
+    ss.parallel(s1, s2, verbose=0)
+    a = _short_summary(s1)
+    b = _short_summary(s2)
+    # Pin: the two summaries must not be byte-identical. (Theoretically
+    # could be equal by chance — astronomically unlikely for a 300-agent
+    # 3-year run.)
+    assert a != b
+
+
+def test_parallel_inplace_true_default_mutates_originals():
+    """ss.parallel(s1, s2) (default inplace=True) leaves s1/s2 with populated results."""
+    s1 = _tiny_sim(rand_seed=0, label='a')
+    s2 = _tiny_sim(rand_seed=1, label='b')
+    ss.parallel(s1, s2, verbose=0)
+    # Both originals carry results after the call.
+    assert float(s1.results.hpv16.cum_infections[-1]) >= 0
+    assert float(s2.results.hpv16.cum_infections[-1]) >= 0
+
+
+def test_parallel_inplace_false_leaves_originals_unrun():
+    """ss.parallel(inplace=False) preserves originals as unrun."""
+    s1 = _tiny_sim(rand_seed=0, label='a')
+    s2 = _tiny_sim(rand_seed=1, label='b')
+    msim = ss.parallel(s1, s2, verbose=0, inplace=False)
+    # The originals are not run; trying to read time-series results raises.
+    # Use a less brittle check: s1.t.ti has not advanced past 0.
+    assert int(getattr(s1.t, 'ti', 0)) == 0
+    assert int(getattr(s2.t, 'ti', 0)) == 0
+    # The MultiSim's internal copies DID run.
+    assert float(msim.sims[0].results.hpv16.cum_infections[-1]) >= 0
+
+
+def test_parallel_copy_inputs_independent_after_construction():
+    """Shared module reference → independent per-sim copies after Sim construction.
+
+    Memory: hpv.Sim deep-copies interventions/analyzers/diseases in __init__.
+    To inspect post-run state we access sim.diseases / sim.interventions, NOT
+    the original passed-in reference.
+    """
+    shared_hpv = hpv.HPV(genotype='hpv16')
+    s1 = hpv.Sim(
+        n_agents=300, location='nigeria', genotypes=[shared_hpv],
+        start=2000, stop=2003, dt=0.25, rand_seed=0, verbose=0, label='a',
+    )
+    s2 = hpv.Sim(
+        n_agents=300, location='nigeria', genotypes=[shared_hpv],
+        start=2000, stop=2003, dt=0.25, rand_seed=1, verbose=0, label='b',
+    )
+    # After construction, each sim's diseases list contains its OWN copy.
+    s1_mod = s1.diseases.hpv16
+    s2_mod = s2.diseases.hpv16
+    assert s1_mod is not s2_mod
+    assert s1_mod is not shared_hpv
+    assert s2_mod is not shared_hpv
+
+    ss.parallel(s1, s2, verbose=0)
+    # Each sim's own module carries its own state post-run.
+    assert s1.diseases.hpv16 is s1_mod
+    assert s2.diseases.hpv16 is s2_mod
+    # Final infection counts can differ since seeds differ.
+    assert float(s1.results.hpv16.cum_infections[-1]) >= 0
+    assert float(s2.results.hpv16.cum_infections[-1]) >= 0
+```
+
+- [ ] **Step 2: Run the tests**
+
+```bash
+python -m pytest tests/test_m07_parallel.py -v
+```
+
+Expected: 5 passed (`test_parallel_inplace_false_leaves_originals_unrun` is the new addition compared to the spec's 4-test outline — splitting `inplace_semantics` into the True/False halves makes each assertion specific).
+
+If `test_parallel_seed_reproducibility` fails, **root-cause the underlying Starsim RNG state issue** (e.g., shared module state, in-place dist consumption across processes); do not relax the equality check.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_m07_parallel.py
+git commit -m "M07: verify ss.parallel + RNG semantics with hpv.Sim (reproducibility/separation/inplace/copy_inputs)"
+```
+
+---
+
+## Task 4: M01 short_summary builder (transmission-only metrics)
+
+**Files:**
+- Create: `tests/regression/short_summary_m01.py`
+- Test: `tests/regression/test_short_summary_m01.py`
+
+M01 is HPV16 transmission-only — no precin/CIN/cancer. So the M03/M02 short_summary's cancer-related metrics don't apply. Three metrics: total HPV infections, mean HPV prevalence, total population (lifted plain from sim.results).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/regression/test_short_summary_m01.py`:
+
+```python
+"""Unit test: M01 short summary returns the right keys + plausible values."""
+import pytest
+
+import hpvsim as hpv
+
+from tests.regression.anchor_m01 import make_sim
+from tests.regression.short_summary_m01 import build_summary_m01, METRIC_KEYS_M01
+
+
+def test_build_summary_m01_keys_and_shape():
+    sim = make_sim()
+    sim.run()
+    out = build_summary_m01(sim)
+    assert set(out.keys()) == set(METRIC_KEYS_M01)
+    assert out['total HPV infections'] >= 0
+    assert 0.0 <= out['mean HPV prevalence (%)'] <= 100.0
+    assert out['total population'] > 0
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+python -m pytest tests/regression/test_short_summary_m01.py -v
+```
+
+Expected: ImportError (anchor_m01 and short_summary_m01 don't exist yet).
+
+- [ ] **Step 3: Implement the summary builder**
+
+Create `tests/regression/short_summary_m01.py`:
+
+```python
+"""M01 short-summary builder (transmission-only, no precin/CIN/cancer).
+
+M01 ports only the SIS transmission core; cancer-related metrics from
+the M02/M03 short_summary do not apply here.
+"""
+import numpy as np
+
+
+METRIC_KEYS_M01 = (
+    'total HPV infections',
+    'mean HPV prevalence (%)',
+    'total population',
+)
+
+
+def build_summary_m01(sim, genotype='hpv16'):
+    """Return the 3-entry M01 summary as a flat dict."""
+    res = sim.results[genotype]
+    pop_scale = float(getattr(sim.pars, 'pop_scale', 1.0) or 1.0)
+
+    n_inf = float(np.asarray(res.new_infections).sum()) * pop_scale
+    mean_prev_pct = 100.0 * float(np.asarray(res.prevalence).mean())
+    total_pop = float(np.asarray(sim.results['n_alive'])[-1])
+
+    return {
+        'total HPV infections': n_inf,
+        'mean HPV prevalence (%)': mean_prev_pct,
+        'total population': total_pop,
+    }
+```
+
+- [ ] **Step 4: Defer test run until Task 5 also creates anchor_m01.py**
+
+The test imports `anchor_m01.make_sim`. Defer the pytest run until Task 5; the import will succeed then.
+
+- [ ] **Step 5: Commit (summary builder only)**
+
+```bash
+git add tests/regression/short_summary_m01.py tests/regression/test_short_summary_m01.py
+git commit -m "M07: add M01 short_summary builder (transmission-only metrics)"
+```
+
+---
+
+## Task 5: M01 anchor PARS
+
+**Files:**
+- Create: `tests/regression/anchor_m01.py`
+
+- [ ] **Step 1: Write the anchor file**
+
+Create `tests/regression/anchor_m01.py`:
+
+```python
+"""M01 anchor scenario for the v2 -> v3 migration regression harness.
+
+Single-genotype HPV16, transmission only (SIS clearance, no precin/CIN/
+cancer progression). Nigeria, 1990-2030 to keep the run short while
+still spanning a credible demographic window.
+
+Pinned anchor pars. Do not change without coordinating with regression baselines.
+"""
+import sys
+from pathlib import Path
+
+import sciris as sc
+
+import hpvsim as hpv
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from short_summary_m01 import build_summary_m01  # noqa: E402
+
+
+PARS = dict(
+    n_agents=10e3,
+    location='nigeria',
+    genotypes=[16],
+    start=1990,
+    stop=2030,
+    dt=0.25,
+    rand_seed=0,
+    verbose=0,
+)
+
+
+def make_sim():
+    """Build (but do not run) the M01 anchor sim."""
+    return hpv.Sim(**sc.dcp(PARS))
+
+
+def run_and_summarize():
+    """Run the M01 anchor sim and return the short summary dict."""
+    sim = make_sim()
+    sim.run()
+    return build_summary_m01(sim)
+
+
+if __name__ == '__main__':
+    short = run_and_summarize()
+    print('Short summary (M01 HPV16 transmission-only):')
+    for k, v in short.items():
+        print(f'  {k:<40} {v:>12.4g}')
+```
+
+- [ ] **Step 2: Run the test from Task 4 to verify the anchor works end-to-end**
+
+```bash
+python -m pytest tests/regression/test_short_summary_m01.py -v
+```
+
+Expected: 1 passed.
+
+- [ ] **Step 3: Sanity-run the anchor as a script**
+
+```bash
+python tests/regression/anchor_m01.py
+```
+
+Expected: prints 3 finite metric lines.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/regression/anchor_m01.py
+git commit -m "M07: add M01 anchor (HPV16 transmission-only, Nigeria 1990-2030)"
+```
+
+---
+
+## Task 6: M02 anchor PARS
+
+**Files:**
+- Create: `tests/regression/anchor_m02.py`
+
+M02 anchor is the existing HPV16 single-genotype baseline target. Reuses M03's `short_summary.build_summary` restricted to HPV16 (no `any.*` aggregate; one genotype = aggregate is the same as that genotype).
+
+- [ ] **Step 1: Write the anchor file**
+
+Create `tests/regression/anchor_m02.py`:
+
+```python
+"""M02 anchor scenario: single-genotype HPV16 with full natural history.
+
+Full HPV16 progression (precin/CIN/cancer + cancer death). Nigeria,
+1990-2060 to cover the full lifetime cancer signal. This is the M02
+acceptance-test target — single-genotype, full natural history.
+
+Pinned anchor pars. Do not change without coordinating with regression baselines.
+"""
+import sys
+from pathlib import Path
+
+import sciris as sc
+
+import hpvsim as hpv
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from short_summary import build_summary  # noqa: E402
+
+
+PARS = dict(
+    n_agents=10e3,
+    location='nigeria',
+    genotypes=[16],
+    start=1990,
+    stop=2060,
+    dt=0.25,
+    rand_seed=0,
+    verbose=0,
+)
+
+GENOTYPES = ('hpv16',)
+
+
+def make_sim():
+    """Build (but do not run) the M02 anchor sim."""
+    return hpv.Sim(**sc.dcp(PARS))
+
+
+def run_and_summarize():
+    """Run the M02 anchor sim and return (short_summary_dict, total_pop).
+
+    short_summary uses the M03 builder restricted to a single genotype.
+    The output has 16 entries: 8 per-genotype (hpv16.*) + 8 aggregate (any.*).
+    """
+    sim = make_sim()
+    sim.run()
+    short = build_summary(sim, genotypes=GENOTYPES)
+    total_pop = float(sim.results['n_alive'][-1])
+    return short, total_pop
+
+
+if __name__ == '__main__':
+    short, total_pop = run_and_summarize()
+    print('Short summary (M02 HPV16 single-genotype):')
+    for k, v in short.items():
+        print(f'  {k:<48} {v:>12.4g}')
+    print(f'  {"total population":<48} {total_pop:>12.4g}')
+```
+
+- [ ] **Step 2: Sanity-run the anchor as a script**
+
+```bash
+python tests/regression/anchor_m02.py
+```
+
+Expected: prints 17 finite metric lines (8 per-genotype + 8 aggregate + total population).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/regression/anchor_m02.py
+git commit -m "M07: add M02 anchor (HPV16 single-genotype full natural history, Nigeria 1990-2060)"
+```
+
+---
+
+## Task 7: Extend multi_seed_v2.py with --anchor flag
+
+**Files:**
+- Modify: `tests/regression/multi_seed_v2.py`
+- Modify: `tests/regression/baseline_v23.py` (add `PARS_HPV16_TRANSMISSION_ONLY` for M01 + `_per_genotype_metrics_v2_m01` if needed; M02 PARS exists as the single-genotype path in `regen_hpv16`)
+
+The v2 baseline script needs three things M07 adds:
+1. Recognize `--anchor m01|m02|m03_4genotype`. Default stays `m03_4genotype` for back-compat.
+2. M01 PARS dict in `baseline_v23.py` for transmission-only HPV16 (no cancer progression). Likely needs to override v2's progression params with safe disables.
+3. M01 summary builder (v2 side) — just 3 metrics matching `short_summary_m01`.
+
+**This task touches v2-side code that runs in a separate v2 env.** All code goes in the v3 repo (since `_v2_legacy/` is quarantined and unused, the regen scripts live in `tests/regression/` and call hpvsim v2 from a separate env). We verify by code review here; the actual baseline regen happens out-of-band.
+
+- [ ] **Step 1: Add M01 PARS + v2-side summary builders to baseline_v23.py**
+
+Open `tests/regression/baseline_v23.py`. Append the following after the existing `PARS_4GENOTYPE` block (around line 170):
+
+```python
+# M01 anchor PARS — single-genotype HPV16, transmission only.
+# Disables v2's cancer-progression machinery so the v2 baseline matches
+# v3's M01 (transmission-only) anchor. The disables are best-effort —
+# regen scripts may need adjustment if v2.3's API has shifted.
+PARS_HPV16_TRANSMISSION_ONLY = dict(
+    n_agents=10e3,
+    total_pop=10_000,
+    pop_scale=1,
+    location='nigeria',
+    genotypes=['hpv16'],
+    start=1990,
+    end=2030,
+    dt=0.25,
+    rand_seed=0,
+    verbose=0,
+    eff_condoms=0,
+)
+
+
+def _summary_v2_m01(sim, gen_idx, gen_key):
+    """v2-side M01 summary: transmission-only 3 metrics."""
+    import numpy as np
+    res = sim.results
+    pop_scale = float(sim.pars.get('pop_scale', 1.0) or 1.0)
+    inf_arr = np.asarray(res['infections'][gen_idx, :], dtype=float)
+    n_inf = float(inf_arr.sum()) * pop_scale
+    prev_arr = np.asarray(res['hpv_prevalence'][gen_idx, :], dtype=float)
+    mean_prev_pct = 100.0 * float(prev_arr.mean())
+    total_pop = float(np.asarray(res['n_alive'])[-1])
+    return {
+        'total HPV infections': n_inf,
+        'mean HPV prevalence (%)': mean_prev_pct,
+        'total population': total_pop,
+    }
+```
+
+- [ ] **Step 2: Add M02 PARS (single-genotype HPV16) to baseline_v23.py**
+
+There may or may not already be one — `regen_hpv16(...)` reads from somewhere. Search:
+
+```bash
+grep -n "PARS_HPV16\|genotypes=\['hpv16'\]" tests/regression/baseline_v23.py
+```
+
+If `PARS_HPV16` is not defined, add it after `PARS_HPV16_TRANSMISSION_ONLY`:
+
+```python
+PARS_HPV16 = dict(
+    n_agents=10e3,
+    total_pop=10_000,
+    pop_scale=1,
+    location='nigeria',
+    genotypes=['hpv16'],
+    start=1990,
+    end=2060,
+    dt=0.25,
+    rand_seed=0,
+    verbose=0,
+    eff_condoms=0,
+)
+```
+
+If it already exists, skip this step.
+
+- [ ] **Step 3: Edit multi_seed_v2.py — add --anchor flag**
+
+Open `tests/regression/multi_seed_v2.py`. Make these targeted edits:
+
+Replace the import block (around lines 28–33):
+
+```python
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from baseline_v23 import (  # noqa: E402
+    PARS_4GENOTYPE,
+    PARS_HPV16,
+    PARS_HPV16_TRANSMISSION_ONLY,
+    _per_genotype_metrics_v2,
+    _aggregate_metrics_v2,
+    _summary_v2_m01,
+)
+```
+
+Replace the `DEFAULT_OUT` constant block:
+
+```python
+DEFAULT_OUT_4GENOTYPE = Path(__file__).resolve().parent / 'v2_seeds_n30.json'
+DEFAULT_OUT_M01 = Path(__file__).resolve().parent / 'v2_m01_seeds_n30.json'
+DEFAULT_OUT_M02 = Path(__file__).resolve().parent / 'v2_m02_seeds_n30.json'
+
+ANCHORS = {
+    'm03_4genotype': dict(
+        pars=PARS_4GENOTYPE,
+        genotypes=('hpv16', 'hpv18', 'hi5', 'ohr'),
+        out=DEFAULT_OUT_4GENOTYPE,
+        mode='m03',
+    ),
+    'm02': dict(
+        pars=PARS_HPV16,
+        genotypes=('hpv16',),
+        out=DEFAULT_OUT_M02,
+        mode='m03',
+    ),
+    'm01': dict(
+        pars=PARS_HPV16_TRANSMISSION_ONLY,
+        genotypes=('hpv16',),
+        out=DEFAULT_OUT_M01,
+        mode='m01',
+    ),
+}
+```
+
+Replace `run_seed` to dispatch on mode:
+
+```python
+def run_seed(seed, anchor='m03_4genotype'):
+    cfg = ANCHORS[anchor]
+    pars = sc.dcp(cfg['pars'])
+    pars['rand_seed'] = int(seed)
+    pars['genotypes'] = list(cfg['genotypes'])
+    sim = hpv.Sim(pars)
+    sim.run()
+
+    summary = {}
+    if cfg['mode'] == 'm03':
+        genotype_map = sim.pars['genotype_map']
+        genotype_pairs = [(i, k) for i, k in sorted(genotype_map.items())]
+        for gen_idx, gen_key in genotype_pairs:
+            per = _per_genotype_metrics_v2(sim, gen_idx, gen_key)
+            for k, v in per.items():
+                summary[f'{gen_key}.{k}'] = float(v)
+        agg = _aggregate_metrics_v2(sim, genotype_pairs)
+        for k, v in agg.items():
+            summary[f'any.{k}'] = float(v)
+    elif cfg['mode'] == 'm01':
+        genotype_map = sim.pars['genotype_map']
+        gen_idx = next(i for i, k in genotype_map.items() if k == 'hpv16')
+        per = _summary_v2_m01(sim, gen_idx, 'hpv16')
+        for k, v in per.items():
+            summary[k] = float(v)
+    else:
+        raise ValueError(f"Unknown anchor mode: {cfg['mode']}")
+
+    summary['_seed'] = int(seed)
+    if 'n_alive' in sim.results:
+        summary['_total_pop'] = float(sim.results['n_alive'][-1])
+    else:
+        summary['_total_pop'] = float(sim.results['pop_size'][-1])
+    return summary
+```
+
+Replace `main()` to add the `--anchor` flag:
+
+```python
+def main(argv=None):
+    p = argparse.ArgumentParser()
+    p.add_argument('--anchor', choices=list(ANCHORS), default='m03_4genotype',
+                   help='Anchor to run (m01, m02, or m03_4genotype).')
+    p.add_argument('--n', type=int, default=30)
+    p.add_argument('--start-seed', type=int, default=0)
+    p.add_argument('--out', type=Path, default=None,
+                   help='Override the default output path for this anchor.')
+    args = p.parse_args(argv)
+
+    out_path = args.out or ANCHORS[args.anchor]['out']
+    seeds = list(range(args.start_seed, args.start_seed + args.n))
+    results = []
+    t0 = time.time()
+    for seed in seeds:
+        ts = time.time()
+        s = run_seed(seed, anchor=args.anchor)
+        dt = time.time() - ts
+        results.append(s)
+        # Pick one diagnostic metric for the progress line.
+        diag_key = next(iter(k for k in s if k not in ('_seed', '_total_pop')))
+        print(f'  seed {seed} ({args.anchor}): done in {dt:.1f}s '
+              f'({diag_key}={s[diag_key]:.4g})')
+    total = time.time() - t0
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(out_path, 'w') as f:
+        json.dump(results, f, indent=2)
+    print(f'Wrote {len(results)} seed summaries to {out_path} in {total:.1f}s')
+```
+
+Remove the now-unused `DEFAULT_OUT` and `DEFAULT_GENOTYPES` constants and the old `--genotypes` flag — they're replaced by the `ANCHORS` table.
+
+- [ ] **Step 4: Syntax-check the edited scripts in the v3 env**
+
+```bash
+python -c "import ast; ast.parse(open('tests/regression/multi_seed_v2.py').read()); print('OK')"
+python -c "import ast; ast.parse(open('tests/regression/baseline_v23.py').read()); print('OK')"
+```
+
+Expected: `OK` printed twice. These scripts run under v2 hpvsim, NOT v3, so actual execution is deferred to the engineer's v2 env. We only syntax-check here.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/regression/multi_seed_v2.py tests/regression/baseline_v23.py
+git commit -m "M07: extend multi_seed_v2 with --anchor m01|m02|m03_4genotype"
+```
+
+---
+
+## Task 8: M01 multi-seed parity test (gated on baseline)
+
+**Files:**
+- Create: `tests/test_m01_short_summary_parity.py`
+
+The test follows the M03 template exactly, swapping anchor + summary builder + threshold, and using the new `parity_gate()` helper.
+
+- [ ] **Step 1: Write the test file**
+
+Create `tests/test_m01_short_summary_parity.py`:
+
+```python
+"""M01 acceptance gate: multi-seed mean parity vs. v2 HPV16-transmission baseline.
+
+Runs N_V3_SEEDS v3 seeds with the M01 anchor PARS, then gates each
+short-summary metric on
+
+    z = (v3_mean - v2_mean) / sqrt(v2_SE^2 + v3_SE^2)
+
+and fails any metric with |z| > Z_THRESHOLD. The v2 baseline is the
+30-seed sweep at tests/regression/v2_m01_seeds_n30.json (gitignored;
+regenerate via ``multi_seed_v2.py --anchor m01 --n 30`` from a v2 env).
+"""
+import json
+from pathlib import Path
+
+import pytest
+import sciris as sc
+
+import hpvsim as hpv
+
+from tests.regression.anchor_m01 import PARS
+from tests.regression.short_summary_m01 import build_summary_m01
+from tests.regression.parity import parity_gate
+
+
+BASELINE_PATH = Path('tests/regression/v2_m01_seeds_n30.json')
+N_V3_SEEDS = 30
+Z_THRESHOLD = 3.0
+
+_SKIP_KEYS = frozenset({'_seed', '_total_pop'})
+
+
+def _run_v3_seeds(n, start_seed=0):
+    summaries = []
+    for seed in range(start_seed, start_seed + n):
+        pars = sc.dcp(PARS)
+        pars['rand_seed'] = int(seed)
+        sim = hpv.Sim(**pars)
+        sim.run()
+        summaries.append(build_summary_m01(sim))
+    return summaries
+
+
+@pytest.mark.slow
+def test_m01_short_summary_parity():
+    if not BASELINE_PATH.exists():
+        pytest.skip(
+            f'Missing v2 M01 baseline at {BASELINE_PATH}. Regenerate via '
+            f'`python tests/regression/multi_seed_v2.py --anchor m01 --n 30` '
+            f'from a v2 hpvsim env.'
+        )
+    v2_rows = json.loads(BASELINE_PATH.read_text())
+    v3_rows = _run_v3_seeds(N_V3_SEEDS, start_seed=0)
+
+    failures = parity_gate(
+        v3_rows, v2_rows, z_threshold=Z_THRESHOLD, skip_keys=_SKIP_KEYS,
+    )
+
+    if failures:
+        details = '\n'.join(
+            f'  {name:<40} z={z:+.2f}' for name, z in failures
+        )
+        pytest.fail(
+            f'M01 mean parity drift exceeds |z|>{Z_THRESHOLD} on '
+            f'{len(failures)} metrics (v2 n={len(v2_rows)}, v3 n={len(v3_rows)}):\n{details}'
+        )
+```
+
+- [ ] **Step 2: Verify the test SKIPs cleanly when no baseline is present**
+
+```bash
+python -m pytest tests/test_m01_short_summary_parity.py -v -m slow
+```
+
+Expected: 1 skipped with message pointing at `multi_seed_v2.py --anchor m01`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_m01_short_summary_parity.py
+git commit -m "M07: add M01 multi-seed short-summary parity gate (skip if baseline absent)"
+```
+
+---
+
+## Task 9: M02 multi-seed parity test (gated on baseline)
+
+**Files:**
+- Create: `tests/test_m02_short_summary_parity.py`
+
+Same template as Task 8 but uses the full M03 short_summary restricted to HPV16.
+
+- [ ] **Step 1: Write the test file**
+
+Create `tests/test_m02_short_summary_parity.py`:
+
+```python
+"""M02 acceptance gate: multi-seed mean parity vs. v2 HPV16 baseline.
+
+Runs N_V3_SEEDS v3 seeds with the M02 anchor PARS, then gates each
+short-summary metric on
+
+    z = (v3_mean - v2_mean) / sqrt(v2_SE^2 + v3_SE^2)
+
+and fails any metric with |z| > Z_THRESHOLD. The v2 baseline is the
+30-seed sweep at tests/regression/v2_m02_seeds_n30.json (gitignored;
+regenerate via ``multi_seed_v2.py --anchor m02 --n 30`` from a v2 env).
+"""
+import json
+from pathlib import Path
+
+import pytest
+import sciris as sc
+
+import hpvsim as hpv
+
+from tests.regression.anchor_m02 import PARS, GENOTYPES
+from tests.regression.short_summary import build_summary
+from tests.regression.parity import parity_gate
+
+
+BASELINE_PATH = Path('tests/regression/v2_m02_seeds_n30.json')
+N_V3_SEEDS = 30
+Z_THRESHOLD = 3.0
+
+_SKIP_KEYS = frozenset({'_seed', '_total_pop', 'total population'})
+
+
+def _run_v3_seeds(n, start_seed=0):
+    summaries = []
+    for seed in range(start_seed, start_seed + n):
+        pars = sc.dcp(PARS)
+        pars['rand_seed'] = int(seed)
+        sim = hpv.Sim(**pars)
+        sim.run()
+        summaries.append(build_summary(sim, genotypes=GENOTYPES))
+    return summaries
+
+
+@pytest.mark.slow
+def test_m02_short_summary_parity():
+    if not BASELINE_PATH.exists():
+        pytest.skip(
+            f'Missing v2 M02 baseline at {BASELINE_PATH}. Regenerate via '
+            f'`python tests/regression/multi_seed_v2.py --anchor m02 --n 30` '
+            f'from a v2 hpvsim env.'
+        )
+    v2_rows = json.loads(BASELINE_PATH.read_text())
+    v3_rows = _run_v3_seeds(N_V3_SEEDS, start_seed=0)
+
+    failures = parity_gate(
+        v3_rows, v2_rows, z_threshold=Z_THRESHOLD, skip_keys=_SKIP_KEYS,
+    )
+
+    if failures:
+        details = '\n'.join(
+            f'  {name:<50} z={z:+.2f}' for name, z in failures
+        )
+        pytest.fail(
+            f'M02 mean parity drift exceeds |z|>{Z_THRESHOLD} on '
+            f'{len(failures)} metrics (v2 n={len(v2_rows)}, v3 n={len(v3_rows)}):\n{details}'
+        )
+```
+
+- [ ] **Step 2: Verify the test SKIPs cleanly**
+
+```bash
+python -m pytest tests/test_m02_short_summary_parity.py -v -m slow
+```
+
+Expected: 1 skipped with message pointing at `multi_seed_v2.py --anchor m02`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_m02_short_summary_parity.py
+git commit -m "M07: add M02 multi-seed short-summary parity gate (skip if baseline absent)"
+```
+
+---
+
+## Task 10: vx-coverage sweep demo
+
+**Files:**
+- Create: `examples/m07_uq_sweep.py`
+
+- [ ] **Step 1: Confirm M05 anchor file exists with PARS**
+
+```bash
+python -c "from tests.regression.anchor_vx_routine import PARS; print(list(PARS.keys())[:5])"
+```
+
+Expected: prints a small list of key names. If this fails, M05 is not yet on the branch; pause and verify branch parentage.
+
+- [ ] **Step 2: Confirm the routine_vx kwarg is `prob`**
+
+```bash
+python -c "import starsim as ss, inspect; print(inspect.signature(ss.RoutineDelivery.__init__))"
+```
+
+Expected: signature shows `prob=None` among kwargs.
+
+- [ ] **Step 3: Write the demo script**
+
+Create `examples/m07_uq_sweep.py`:
+
+```python
+"""M07 demo: vaccination-coverage sweep with multi-seed UQ.
+
+Runs a 4 × 20 (coverage × seed) routine-vx sweep on the M05 Nigeria
+4-genotype anchor, reduces each coverage scenario to median + 10/90
+quantiles, and plots age-stratified cancer incidence by coverage.
+
+Exercises every M07 verification target:
+  - sc.parallelize for parallel sim CREATION
+  - ss.parallel for parallel sim EXECUTION
+  - ss.MultiSim.median for result REDUCTION
+  - make_sim(seed, scenario) is the Starsim-native replacement for v2's
+    hpv.Scenarios.
+
+Run from the repo root:
+    python examples/m07_uq_sweep.py
+Produces:
+    m07_uq_sweep.png  (cancer incidence by age, by coverage, with CIs)
+"""
+import argparse
+from pathlib import Path
+
+import numpy as np
+import sciris as sc
+import starsim as ss
+import hpvsim as hpv
+
+from tests.regression.anchor_vx_routine import PARS as VX_PARS
+
+
+COVERAGES = [0.0, 0.3, 0.6, 0.9]
+N_SEEDS = 20
+
+
+def make_sim(seed, coverage):
+    """Build one sim. The intervention is built fresh per sim — Sim
+    deep-copies inputs, so post-run inspection must go through
+    sim.interventions, not the local reference. See [[feedback_sim_input_copy]].
+    """
+    kwargs = sc.dcp(VX_PARS)
+    kwargs['rand_seed'] = int(seed)
+    kwargs['label'] = f'coverage={coverage:.0%}|seed={seed}'
+    kwargs['interventions'] = [hpv.routine_vx(
+        product='bivalent', prob=float(coverage), age_range=(9, 14), sex='f',
+    )]
+    return hpv.Sim(**kwargs)
+
+
+def main(out_png=Path('m07_uq_sweep.png')):
+    iterkwargs = [dict(seed=s, coverage=c)
+                  for c in COVERAGES for s in range(N_SEEDS)]
+    print(f'Building {len(iterkwargs)} sims via sc.parallelize...')
+    sims = sc.parallelize(make_sim, iterkwargs=iterkwargs)
+
+    print(f'Running {len(sims)} sims via ss.parallel...')
+    msim = ss.parallel(*sims, verbose=0)
+
+    # Group sims back into per-coverage MultiSims for reduction.
+    by_cov = {}
+    for cov in COVERAGES:
+        tag = f'coverage={cov:.0%}'
+        cov_sims = [s for s in msim.sims if s.label.startswith(tag)]
+        sub = ss.MultiSim(cov_sims)
+        sub.median()
+        by_cov[cov] = sub
+
+    _plot_coverage_sweep(by_cov, out_png)
+    print(f'Wrote {out_png}')
+
+
+def _plot_coverage_sweep(by_cov, out_png):
+    import matplotlib.pyplot as plt
+    fig, ax = plt.subplots(figsize=(8, 5))
+    for cov, sub_msim in by_cov.items():
+        # Pull aggregate cancer incidence trajectory from the reduced msim.
+        # Result key is the same as the per-sim result key after reduce.
+        res = sub_msim.results.hpvtotal
+        years = np.asarray(res.timevec)
+        median = np.asarray(res.new_cancers)
+        # Reduce() exposes low/high on each result entry by default.
+        lo = np.asarray(getattr(res.new_cancers, 'low', median))
+        hi = np.asarray(getattr(res.new_cancers, 'high', median))
+        line, = ax.plot(years, median, label=f'coverage={cov:.0%}')
+        ax.fill_between(years, lo, hi, alpha=0.2, color=line.get_color())
+    ax.set_xlabel('Year')
+    ax.set_ylabel('New cancers (per step)')
+    ax.set_title('Cancer trajectories by routine-vx coverage (median + 10/90)')
+    ax.legend()
+    fig.tight_layout()
+    fig.savefig(out_png, dpi=150)
+    plt.close(fig)
+
+
+if __name__ == '__main__':
+    p = argparse.ArgumentParser()
+    p.add_argument('--out', type=Path, default=Path('m07_uq_sweep.png'))
+    args = p.parse_args()
+    main(out_png=args.out)
+```
+
+- [ ] **Step 4: Run the demo end-to-end**
+
+```bash
+python examples/m07_uq_sweep.py
+```
+
+Expected: prints progress, produces `m07_uq_sweep.png` (a 4-line plot). Runtime: minutes (80 sims on the M05 anchor).
+
+If the plot helper fails on `.low`/`.high` attribute lookup, replace the `getattr(..., 'low', median)` fallbacks with direct dict access matching Starsim's actual reduce output (inspect `sub_msim.results` interactively).
+
+- [ ] **Step 5: Commit (include the PNG only if Robyn wants it tracked; default = gitignore)**
+
+```bash
+# Confirm the PNG is gitignored (project .gitignore should catch *.png at repo root).
+git status --short | grep m07_uq_sweep.png || true
+git add examples/m07_uq_sweep.py
+git commit -m "M07: add vx-coverage sweep demo (4x20 seeds, median+10/90 plot)"
+```
+
+---
+
+## Task 11: Demo smoke test
+
+**Files:**
+- Create: `tests/test_m07_demo_smoke.py`
+
+A tiny 1 × 2 (coverage × seed) variant of the demo so CI catches the demo bit-rotting without running the full 80-sim version.
+
+- [ ] **Step 1: Write the smoke test**
+
+Create `tests/test_m07_demo_smoke.py`:
+
+```python
+"""Tiny smoke variant of examples/m07_uq_sweep.py so CI catches bit rot.
+
+Uses 1 coverage × 2 seeds. Verifies the make_sim + ss.parallel + ss.MultiSim
++ median pipeline executes and produces non-trivial results — NOT a parity
+gate. Real-shape demo lives in examples/m07_uq_sweep.py.
+"""
+import sciris as sc
+import starsim as ss
+import hpvsim as hpv
+
+
+def _make_tiny_vx_sim(seed, coverage):
+    return hpv.Sim(
+        n_agents=500,
+        location='nigeria',
+        genotypes=[16],
+        start=2010,
+        stop=2013,
+        dt=0.25,
+        rand_seed=int(seed),
+        verbose=0,
+        label=f'coverage={coverage:.0%}|seed={seed}',
+        interventions=[hpv.routine_vx(
+            product='bivalent', prob=float(coverage),
+            age_range=(9, 14), sex='f',
+        )],
+    )
+
+
+def test_demo_pipeline_runs_end_to_end():
+    """sc.parallelize + ss.parallel + ss.MultiSim.median works on hpv.Sim."""
+    iterkwargs = [dict(seed=s, coverage=0.6) for s in range(2)]
+    sims = sc.parallelize(_make_tiny_vx_sim, iterkwargs=iterkwargs)
+    msim = ss.parallel(*sims, verbose=0)
+    sub = ss.MultiSim(list(msim.sims))
+    sub.median()
+    # Median-reduced result has the same shape as each underlying sim.
+    cum_inf = sub.results.hpv16.cum_infections
+    assert len(cum_inf) > 0
+    assert float(cum_inf[-1]) >= 0
+```
+
+- [ ] **Step 2: Run the test**
+
+```bash
+python -m pytest tests/test_m07_demo_smoke.py -v
+```
+
+Expected: 1 passed. Runtime < 30 s.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_m07_demo_smoke.py
+git commit -m "M07: add demo smoke test (1x2 coverage/seed pipeline check)"
+```
+
+---
+
+## Task 12: Update tut_running.qmd
+
+**Files:**
+- Modify: `docs/tutorials/tut_running.qmd`
+
+Replace the v2 `hpv.Scenarios` section with a Starsim-native walk-through. The exact location to replace depends on the current file; the next step locates it.
+
+- [ ] **Step 1: Locate the v2 Scenarios section**
+
+```bash
+grep -n "Scenarios\|MultiSim\|scenarios=" docs/tutorials/tut_running.qmd
+```
+
+Note the line range of the existing `Scenarios` section. The replacement preserves any surrounding intro/outro paragraphs unrelated to Scenarios.
+
+- [ ] **Step 2: Replace the Scenarios subsection**
+
+Open `docs/tutorials/tut_running.qmd`. Replace the v2-`Scenarios` subsection (located in Step 1) with:
+
+````markdown
+## Multi-seed runs and scenario sweeps
+
+HPVsim v3 uses Starsim's native multi-sim machinery — `ss.MultiSim`,
+`ss.parallel`, and Sciris's `sc.parallelize` — for replicate runs,
+scenario comparisons, and parameter sweeps. v2's `hpv.Scenarios` class
+has been removed; the pattern below is the Starsim-native replacement.
+
+### Replicate runs (multi-seed UQ)
+
+```python
+import starsim as ss
+import hpvsim as hpv
+
+sim = hpv.Sim(n_agents=10e3, location='nigeria', genotypes=[16, 18, 'hi5', 'ohr'])
+msim = ss.MultiSim(sim, n_runs=20).run(verbose=0)
+msim.median()        # mutates msim in place to median + 10/90 quantiles
+msim.plot()
+```
+
+### Comparing scenarios
+
+Use a `make_sim(seed, scenario)` factory and pass labeled sims to
+`ss.parallel`:
+
+```python
+import sciris as sc
+
+def make_sim(seed, coverage):
+    return hpv.Sim(
+        rand_seed=seed,
+        label=f'coverage={coverage:.0%}',
+        interventions=[hpv.routine_vx(
+            product='bivalent', prob=coverage, age_range=(9, 14), sex='f',
+        )],
+        # ... other PARS
+    )
+
+sims = [make_sim(seed=0, coverage=c) for c in [0.0, 0.3, 0.6, 0.9]]
+msim = ss.parallel(*sims, verbose=0)
+msim.plot()
+```
+
+### Sweeping parameters with multi-seed UQ
+
+Combine both: `sc.parallelize` builds sims across a parameter grid;
+`ss.parallel` runs them; group by scenario for UQ:
+
+```python
+COVERAGES = [0.0, 0.3, 0.6, 0.9]
+N_SEEDS = 20
+
+iterkwargs = [dict(seed=s, coverage=c) for c in COVERAGES for s in range(N_SEEDS)]
+sims = sc.parallelize(make_sim, iterkwargs=iterkwargs)
+msim = ss.parallel(*sims, verbose=0)
+
+by_cov = {}
+for cov in COVERAGES:
+    sub = ss.MultiSim([s for s in msim.sims if s.label.startswith(f'coverage={cov:.0%}')])
+    sub.median()
+    by_cov[cov] = sub
+```
+
+A full worked example lives in `examples/m07_uq_sweep.py`.
+
+### Migrating from v2's `hpv.Scenarios`
+
+| v2 pattern | v3 replacement |
+|---|---|
+| `hpv.Scenarios(scenarios={'low': {...}, 'high': {...}})` | `make_sim(seed, scenario)` factory + `ss.parallel(*sims)` |
+| `scens.run()` | `ss.parallel(*sims)` |
+| `scens.results['low']` | filter `msim.sims` by label, wrap in `ss.MultiSim` |
+| `hpv.MultiSim(sim, n_runs=N)` | `ss.MultiSim(sim, n_runs=N)` (same name in Starsim) |
+| `hpv.parallel(s1, s2)` | `ss.parallel(s1, s2)` (same name in Starsim) |
+
+Note: `sim.median()` and `sim.mean()` **mutate** the MultiSim in place.
+Prefer `.median()` for bounded metrics (cancers, infections, prevalence) —
+mean ± 2 SD can produce non-physical lower bounds.
+````
+
+- [ ] **Step 3: Visually skim the rendered or raw file to confirm no orphan v2 `Scenarios` references**
+
+```bash
+grep -n "hpv\.Scenarios\|hpvsim\.Scenarios\|Sweep" docs/tutorials/tut_running.qmd
+```
+
+Expected: only matches inside the "Migrating from v2" subsection (the comparison table).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/tutorials/tut_running.qmd
+git commit -m "M07: replace v2 hpv.Scenarios tutorial section with Starsim-native pattern"
+```
+
+---
+
+## Task 13: Update MIGRATION_PLAN.md M07 sub-task list
+
+**Files:**
+- Modify: `MIGRATION_PLAN.md`
+
+The M07 sub-task list still says "Port the Scenarios class" and "Port the Sweep class" — neither happens. Replace with the actual scope.
+
+- [ ] **Step 1: Edit the M07 sub-tasks**
+
+Open `MIGRATION_PLAN.md`. Locate the M07 sub-tasks block (currently at lines 278–283). Replace it with:
+
+```markdown
+**Sub-tasks:**
+- Verify `ss.MultiSim` works with `hpv.Sim` (multi-seed runs, result aggregation, median + quantiles).
+- Verify `ss.parallel()` works with proper random-seed handling (same-seed reproducibility, copy_inputs semantics, inplace semantics).
+- Retrofit M01 and M02 acceptance tests onto multi-seed z-score parity gates matching the M03 standard (`|z| < 3` over 30 v3 seeds vs 30 v2 seeds). M03 and M05 already pass under multi-seed gates; M04 (calibration) and M06 (screen-and-treat) own their own UQ as part of their milestone scopes.
+- Add a shared `parity_gate()` helper in `tests/regression/parity.py` consumed by the new M01/M02 tests. Refactoring M03/M05 tests onto the helper is tracked as a post-merge follow-up.
+- Demo: `examples/m07_uq_sweep.py` — 4 × 20 (coverage × seed) routine-vx sweep on the M05 Nigeria anchor, with median + 10/90 quantile cancer-incidence-by-age plot. Smoke variant at `tests/test_m07_demo_smoke.py`.
+- Rewrite `docs/tutorials/tut_running.qmd`'s v2 `Scenarios` section onto Starsim-native `make_sim(seed, scenario)` + `ss.parallel` / `sc.parallelize` pattern.
+- **Dropped from M07 scope:** no `hpv.Scenarios` or `hpv.Sweep` shim; users use Starsim-native APIs directly. Validation repos (`hpvsim_methods_manuscript`, etc.) drop `hpv.Scenarios` imports as a separate post-M07 PR per repo, coordinated with Robyn per RACI.
+```
+
+- [ ] **Step 2: Update the M07 status entry**
+
+In the milestone status table (lines 73–82), change the `M6–M10` row to leave M7 either In Progress or split out a dedicated M07 row, e.g.:
+
+```markdown
+| M5 | 🟡 Implementation complete; PR not yet opened | branch `m05-vaccination-scenarios` |
+| M6 | 🟡 In progress | branch `m06-test-and-treat-cascade` |
+| M7 | 🟡 In progress | branch `m07-multisim` |
+| M8–M10 | ⬜ Not started | — |
+```
+
+(M06's status reflects the other Claude instance's work; verify it's correct before committing.)
+
+- [ ] **Step 3: Verify no dangling references**
+
+```bash
+grep -n "Port the Scenarios\|Port the Sweep" MIGRATION_PLAN.md
+```
+
+Expected: no matches.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add MIGRATION_PLAN.md
+git commit -m "M07: realign MIGRATION_PLAN sub-task list (drop Scenarios/Sweep port; add retrofit + demo)"
+```
+
+---
+
+## Task 14: Update tests/regression/README.md
+
+**Files:**
+- Modify: `tests/regression/README.md` (create if missing)
+
+- [ ] **Step 1: Check whether the file exists**
+
+```bash
+ls tests/regression/README.md 2>&1
+```
+
+If missing, create it. If present, append the new section.
+
+- [ ] **Step 2: Add an "Anchors" section**
+
+If the file exists, append; if creating fresh, write the full content. The minimum needed addition:
+
+```markdown
+## Regression anchors and baseline regeneration
+
+Each milestone has an "anchor" sim — fixed PARS, single canonical
+configuration — used as the regression target against v2.3 baselines.
+Baselines are generated locally from a v2.3 hpvsim env and gitignored.
+
+| Anchor | PARS file | Summary builder | v2 baseline (gitignored) | v2 regen command |
+|---|---|---|---|---|
+| M01 | `anchor_m01.py` | `short_summary_m01.py::build_summary_m01` | `v2_m01_seeds_n30.json` | `python tests/regression/multi_seed_v2.py --anchor m01 --n 30` |
+| M02 | `anchor_m02.py` | `short_summary.py::build_summary` (genotypes=('hpv16',)) | `v2_m02_seeds_n30.json` | `python tests/regression/multi_seed_v2.py --anchor m02 --n 30` |
+| M03 | `anchor_4genotype.py` | `short_summary.py::build_summary` | `v2_seeds_n30.json` | `python tests/regression/multi_seed_v2.py --anchor m03_4genotype --n 30` |
+| M05 vx routine | `anchor_vx_routine.py` | (see M05 spec) | `v2_vx_routine_seeds_n30.json` | (see M05 docs) |
+| M05 vx campaign | `anchor_vx_campaign.py` | (see M05 spec) | `v2_vx_campaign_seeds_n30.json` | (see M05 docs) |
+
+### Regenerating from a v2 env
+
+Run all baseline regen scripts from a Python env with `hpvsim==2.3.x`
+installed. The active v3 env does NOT work; the scripts call v2's API.
+
+A local v2 env can be set up as a fresh worktree of `rc2.3`:
+
+```bash
+git worktree add ../hpvsim_v23_frozen rc2.3
+cd ../hpvsim_v23_frozen
+python -m venv .venv-v23
+.venv-v23/bin/pip install -e .
+```
+
+Then run, from the *v3* repo root, with the v2 env's Python:
+
+```bash
+../hpvsim_v23_frozen/.venv-v23/bin/python tests/regression/multi_seed_v2.py \
+    --anchor m01 --n 30 \
+    --out tests/regression/v2_m01_seeds_n30.json
+```
+
+(Adjust paths for Windows or your local setup.)
+
+### Parity-gate test → baseline mapping
+
+The slow parity-gate tests skip themselves if the corresponding baseline
+JSON is missing. The skip message in pytest output points at the regen
+command for the specific anchor.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/regression/README.md
+git commit -m "M07: document M01/M02 anchors + baseline regeneration in tests/regression/README.md"
+```
+
+---
+
+## Self-Review
+
+After all tasks complete, run the spec self-review checklist:
+
+**1. Spec coverage:**
+- Verify `ss.MultiSim` works with `hpv.Sim` → Task 2.
+- Verify `ss.parallel` proper random-seed handling → Task 3.
+- M01 retrofit to multi-seed z-score gate → Tasks 4, 5, 7, 8.
+- M02 retrofit to multi-seed z-score gate → Tasks 6, 7, 9.
+- Shared `parity_gate()` helper → Task 1.
+- vx-coverage sweep demo → Task 10.
+- Demo smoke test → Task 11.
+- Tutorial rewrite → Task 12.
+- MIGRATION_PLAN sub-task list realignment → Task 13.
+- `tests/regression/README.md` baseline regen docs → Task 14.
+
+Every spec requirement maps to a task. ✓
+
+**2. Placeholder scan:** none. Every step contains the actual content.
+
+**3. Type/name consistency:**
+- `parity_gate(v3_seeds, v2_seeds, z_threshold=..., skip_keys=...)` — same signature in Tasks 1, 8, 9. ✓
+- `build_summary_m01(sim)` — same call in Tasks 4, 5, 8. ✓
+- `build_summary(sim, genotypes=...)` — used in Tasks 6, 9 (M03's existing signature). ✓
+- `make_sim(seed, coverage)` — same signature in Tasks 10, 11. ✓
+- `PARS` exported from `anchor_m01.py`, `anchor_m02.py` — used by Tasks 8, 9. ✓
+- `GENOTYPES` exported from `anchor_m02.py` — used by Task 9. ✓
+
+**4. Acceptance criteria check (vs spec §"Acceptance criteria"):**
+1. All new tests pass locally and in CI — Tasks 1, 2, 3, 4, 5, 8, 9, 11 verify locally.
+2. `examples/m07_uq_sweep.py` runs end-to-end and produces the figure — Task 10 Step 4.
+3. v2 baselines regenerate — Task 7 syntax-checks the script; engineer runs the actual regen against a v2 env, gated baselines skip cleanly until then.
+4. No `hpv.Scenarios`/`hpv.Sweep` references remain in active docs/examples — Task 12 Step 3.
+5. `MIGRATION_PLAN.md` M07 sub-task list edited — Task 13.
+
+All acceptance criteria covered. ✓
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-05-27-m07-multisim.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration.
+
+**2. Inline Execution** — Execute tasks in this session using executing-plans, batch execution with checkpoints.
+
+Which approach?

--- a/docs/superpowers/plans/2026-05-27-m07-multisim.md
+++ b/docs/superpowers/plans/2026-05-27-m07-multisim.md
@@ -10,7 +10,7 @@
 
 **Spec:** [`docs/superpowers/specs/2026-05-27-m07-multisim-design.md`](../specs/2026-05-27-m07-multisim-design.md)
 
-**Branch:** all commits land on `m07-multisim`. PR targets `v3.0-dev` after `m05-vaccination-scenarios` merges (M07's demo depends on M05). If implementation finishes before M05 lands, hold PR in draft.
+**Branch:** all commits land on `m07-multisim`. The branch was rebased onto `m06-test-and-treat-cascade` (which includes M05's history) on 2026-05-28. PR targets `v3.0-dev` directly, held in draft until M05 and M06 land on `v3.0-dev`. If M05/M06 land with conflicting edits, rebase once more onto the updated `v3.0-dev`.
 
 ---
 

--- a/docs/superpowers/specs/2026-05-27-m07-multisim-design.md
+++ b/docs/superpowers/specs/2026-05-27-m07-multisim-design.md
@@ -1,0 +1,503 @@
+# M07: MultiSim and Scenarios — Design
+
+**Date:** 2026-05-27
+**Milestone:** M07 (MultiSim and scenarios)
+**Branch:** `m07-multisim` (off `m05-vaccination-scenarios`; PR targets `v3.0-dev`)
+**Predecessor:** [M05 Vaccination Scenarios](2026-05-20-m05-vaccination-scenarios-design.md)
+**Status:** Design — not yet implemented.
+
+## Dependencies and rebase strategy
+
+M07 branches off `m05-vaccination-scenarios` rather than `v3.0-dev` because
+the demo (`examples/m07_uq_sweep.py`) and its smoke test
+(`tests/test_m07_demo_smoke.py`) consume M05 deliverables: `hpv.routine_vx`,
+`hpv.vx`, the Nigeria 4-genotype vaccination anchor at
+`tests/regression/anchor_vx_routine.py`, and `products_vx.csv`. The
+verification tests (`test_m07_multisim.py`, `test_m07_parallel.py`) and the
+M01/M02 parity-gate tests do not depend on M05.
+
+Once M05 merges to `v3.0-dev`, this branch rebases onto `v3.0-dev` and the
+M07 PR targets `v3.0-dev` directly. If M07 finishes implementation before
+M05 merges, the PR is held in draft against `v3.0-dev` with M05's diff
+visible until M05 lands. (Same pattern as M03, which branched off
+`m02-natural-history-parity` and rebased onto `v3.0-dev` after M02 merged.)
+
+---
+
+## Goal
+
+Make `hpv.Sim` first-class with Starsim's multi-sim machinery so that users can
+quantify uncertainty and compare scenarios using stock Starsim APIs, without any
+hpvsim-specific wrapper machinery. After M07, a user can:
+
+1. Run N seeds of any hpvsim configuration via `ss.MultiSim(sim).run()` and
+   reduce to median + 10/90 quantiles.
+2. Compare scenarios via `ss.parallel(*sims)` with proper sim labeling.
+3. Sweep parameters via `sc.parallelize(make_sim, iterkwargs=...)` +
+   `ss.parallel(*sims)`.
+
+The M01 and M02 acceptance gates upgrade from single-seed deterministic
+comparisons to multi-seed z-score parity gates matching the M03 standard
+(30 v3 seeds vs 30 v2 seeds, `|z| < 3` per short-summary metric).
+
+The work that lands in M07 is intentionally small. Starsim already ships
+`ss.MultiSim` (with `mean`/`median`/`reduce`/`plot`), `ss.parallel`, and
+`sc.parallelize`. M07 ships **zero new production code under `hpvsim/`** — its
+deliverables are verification tests, two new milestone parity-gate test
+families, one demo example, and a tutorial-section rewrite.
+
+## Scope
+
+**In scope:**
+
+- Verification tests that `ss.MultiSim(hpv.Sim(...))` and
+  `ss.parallel(hpv.Sim(...), ...)` produce expected behavior — including seed
+  reproducibility (same `rand_seed` → identical results) and the documented
+  Starsim `inplace=True` / `copy_inputs=True` semantics.
+- New M01 and M02 multi-seed parity gates
+  (`tests/test_m01_short_summary_parity.py`,
+  `tests/test_m02_short_summary_parity.py`) mirroring the M03 short-summary
+  z-score gate. Existing single-seed M01/M02 tests stay as fast smoke gates.
+- Shared `parity_gate(v3_seeds, v2_seeds, z_threshold)` helper extracted to
+  `tests/regression/parity.py` and consumed by the new M01/M02 tests.
+- v2 30-seed baselines for M01 and M02 anchors, generated via an extended
+  `tests/regression/multi_seed_v2.py --anchor m0{1,2}` (output gitignored,
+  regenerated locally).
+- M07 demo: `examples/m07_uq_sweep.py` running a 4×20 (coverage × seed)
+  routine-vx sweep on the M05 Nigeria anchor, producing a median + 10/90
+  cancer-incidence-by-age plot. A tiny smoke variant of the demo lives in
+  `tests/test_m07_demo_smoke.py` so the example doesn't rot.
+- Tutorial section in `docs/tutorials/tut_running.qmd`: replace v2's
+  `hpv.Scenarios` section with a walk-through of the Starsim-native
+  `make_sim(seed, scenario)` + `ss.parallel` pattern, plus a short
+  "migrating from v2 Scenarios" subsection.
+- `MIGRATION_PLAN.md` M07 sub-task list edited to match the actual scope
+  (drop the two "Port" sub-tasks; add the retrofit + demo sub-tasks).
+
+**Explicitly out of scope (deferred / dropped):**
+
+- `hpv.Scenarios`, `hpv.Sweep` — dropped. No shim, no subclass, no
+  re-export. Users use Starsim-native `make_sim(seed, scenario)` +
+  `ss.parallel` / `sc.parallelize` directly. Validation repos that import
+  `hpvsim.Scenarios` migrate as separate post-M07 work, coordinated with
+  Robyn per RACI.
+- Re-running M03 / M05 parity tests under different UQ thresholds — they
+  already pass at `|z| < 3` and `|z| < 5` respectively and remain
+  authoritative.
+- Refactoring M03 / M05 parity tests onto the new `parity_gate()` helper.
+  Tracking-issue follow-up; not gating M07.
+- Tightening partnership-network parity beyond M01's wide single-seed
+  thresholds — separate M02-followup issue (MIGRATION_PLAN line 131).
+  M01's partnership-pattern metrics (`n_pairs`, `mean_dur`, `mixing-cosine`)
+  are categorical/distributional and remain outside the z-score framework
+  in M07.
+- M04 (calibration) and M06 (screen-and-treat) UQ — those milestones own
+  their own UQ gates as part of their scopes.
+- Any new `hpvsim/run.py` or other v3 production module. Nothing needs to
+  live there.
+- CRN across truly different parameter values — covered narrowly by the
+  same-seed-same-sim test in M07; full cross-scenario CRN audit is a
+  follow-up.
+- Internal seeding work (`hpvsim/seeding.py`, `_ExclusiveSeeder`). M07 is a
+  multi-sim concern, not a per-sim RNG concern.
+
+---
+
+## Architecture
+
+### Module layout
+
+```
+hpvsim/
+    (no new modules)              # M07 ships ZERO new production code
+hpvsim/__init__.py                # no new re-exports — users import
+                                  # ss.MultiSim / ss.parallel from starsim
+tests/
+├── regression/
+│   ├── parity.py                 # NEW — shared parity_gate() helper       ~80 LOC
+│   ├── anchor_m01.py             # NEW — M01 anchor PARS (1-genotype HPV16) ~40 LOC
+│   ├── anchor_m02.py             # NEW — M02 anchor PARS (HPV16 + nat hist) ~40 LOC
+│   └── multi_seed_v2.py          # EDITED — add --anchor m01/m02 flag       patch
+├── test_m01_short_summary_parity.py   # NEW — 30-seed z-score gate         ~120 LOC
+├── test_m02_short_summary_parity.py   # NEW — 30-seed z-score gate         ~120 LOC
+├── test_m07_multisim.py               # NEW — verify ss.MultiSim + hpv.Sim  ~80 LOC
+├── test_m07_parallel.py               # NEW — verify ss.parallel + RNG     ~80 LOC
+└── test_m07_demo_smoke.py             # NEW — tiny smoke variant of demo   ~30 LOC
+examples/
+└── m07_uq_sweep.py               # NEW — 4×20 coverage sweep demo          ~120 LOC
+docs/tutorials/
+└── tut_running.qmd               # EDITED — Starsim-native sweep pattern   patch
+```
+
+### Why no new hpvsim modules
+
+The MIGRATION_PLAN M07 sub-task list as drafted called for porting v2's
+`Scenarios` and `Sweep` classes (~800 LOC combined). Both are dropped:
+
+- Starsim's `ss.parallel(*labeled_sims)` already does v2 `Scenarios`'s job in
+  one line, given a `make_sim(seed, scenario)` factory. The factory pattern is
+  the documented Starsim idiom (see the `starsim-dev-run` skill reference).
+- Per the M07 user directive — "use Starsim's functionality whenever
+  possible" — and the implementation convention #3 ("subclass-first
+  delegations must have a tracking issue to strip before M10"), shipping a
+  shim layer that we know will be deleted in M10 has negative ROI.
+- Validation-repo updates are cheap (delete `hpvsim.Scenarios` import,
+  replace with three lines of `make_sim` + `ss.parallel`); they're a single
+  PR per repo, post-M07.
+
+The MIGRATION_PLAN sub-task list is edited as part of this milestone's commit
+to reflect the actual scope.
+
+### Shared parity-gate helper
+
+The z-score formula
+
+```
+z = (mean_v3 - mean_v2) / sqrt(SE_v2^2 + SE_v3^2)
+```
+
+is currently inline in `tests/test_m03_short_summary_parity.py` and the M05
+parity tests. Two new usages (M01, M02) make extraction worthwhile:
+
+```python
+# tests/regression/parity.py
+
+def parity_gate(
+    v3_seeds: list[dict],
+    v2_seeds: list[dict],
+    z_threshold: float = 3.0,
+    skip_keys: frozenset = frozenset(),
+) -> list[tuple[str, float]]:
+    """Return [(metric_name, z)] for metrics exceeding |z| >= z_threshold.
+
+    Each *_seeds entry is a dict {metric_name: value} produced by the
+    milestone's short_summary builder. SEs are computed across seeds within
+    each group.
+    """
+```
+
+Consumed by the new M01/M02 tests only. M03/M05 keep their inline loops in
+M07; a follow-up issue refactors them onto the helper post-merge.
+
+---
+
+## Verification tests
+
+### `tests/test_m07_multisim.py`
+
+Four tests against `ss.MultiSim` + `hpv.Sim`:
+
+1. `test_multisim_n_runs` — `ss.MultiSim(hpv.Sim(...), n_runs=5).run()`
+   returns 5 distinct sims; each sim's `short_summary` is finite and
+   non-degenerate.
+2. `test_multisim_median_reduce` — after `msim.median()`, the per-result
+   median + 10/90 quantile arrays have the right shape and are non-negative
+   for bounded metrics (cancers, infections, deaths).
+3. `test_multisim_mean_reduce` — same shape check for `msim.mean()` as a
+   smoke test. The `starsim-dev-run` skill cautions against `.mean()` for
+   bounded quantities; we don't recommend it, but it must function.
+4. `test_multisim_label_propagation` — labels on individual sims survive
+   into `msim.sims[i].label` and post-reduction result indices.
+
+### `tests/test_m07_parallel.py`
+
+Four tests against `ss.parallel` + `hpv.Sim`:
+
+1. `test_parallel_seed_reproducibility` — two `hpv.Sim(rand_seed=42)`
+   passed through `ss.parallel` produce **identical** `short_summary`
+   per metric. Bit-for-bit equality.
+2. `test_parallel_seed_separation` — two `hpv.Sim` with `rand_seed=0` and
+   `rand_seed=1` produce different but plausibly distributed results; a
+   sanity bound (`|z| < 5` vs M03 anchor's known per-seed CV), not a
+   parity gate.
+3. `test_parallel_inplace_semantics` — `ss.parallel(s1, s2)` (default
+   `inplace=True`) populates `s1.results` and `s2.results`;
+   `ss.parallel(s1, s2, inplace=False)` leaves the originals unrun.
+4. `test_parallel_copy_inputs_semantics` — a shared
+   `hpv.routine_vx(coverage=0.6)` instance passed to two sims yields two
+   independent intervention copies; post-run inspection must access
+   `sim.interventions[...]`, not the original reference. This is the
+   sim-copies-inputs discipline reified as a regression test.
+
+### Test budget
+
+- Verification tests use tiny sims (`n_agents=500`, `dur=2`). Total runtime
+  for both files < 30 s. Marked as the existing default (fast) suite.
+- M01/M02 parity tests use full milestone anchor pars at 30 seeds. Marked
+  `@pytest.mark.slow`, consistent with M03/M05 marking. Picked up by the
+  slow CI job.
+
+### Failure-mode notes
+
+- `test_parallel_seed_reproducibility` is the most likely flake source if
+  Starsim's RNG handling has subtle in-place state. If it flakes, root-cause
+  it rather than relaxing the check.
+- Pre-emptive guard: each test constructs `hpv.Sim` fresh (no `sc.dcp`) to
+  avoid CRN-state leakage from prior test interactions.
+
+---
+
+## M01 / M02 UQ retrofit
+
+### Anchors
+
+Two new tiny PARS-dict modules mirroring `tests/regression/anchor_4genotype.py`
+(M03):
+
+- `tests/regression/anchor_m01.py` — single-genotype HPV16, transmission
+  only (no precin/CIN/cancer), Nigeria, 1990–2030. Matches the M01
+  sub-task scope.
+- `tests/regression/anchor_m02.py` — HPV16 + full natural-history
+  progression, Nigeria, 1990–2060. Matches the M02 sub-task scope.
+
+### v2 baseline generation
+
+Extend `tests/regression/multi_seed_v2.py` with `--anchor` accepting
+`m01` / `m02` / `m03_4genotype` / `m05_vx_routine` / `m05_vx_campaign`.
+Generated baselines live at `tests/regression/v2_m01_seeds_n30.json` and
+`tests/regression/v2_m02_seeds_n30.json` (both gitignored).
+`tests/regression/README.md` updated with regeneration instructions.
+
+### Gates
+
+- `tests/test_m01_short_summary_parity.py`: 30 v3 seeds via
+  `ss.MultiSim(hpv.Sim(**M01_PARS), n_runs=30).run()`. Metrics: total
+  infections, mean HPV prevalence, total population. Threshold `|z| < 3`.
+- `tests/test_m02_short_summary_parity.py`: 30 v3 seeds on M02 anchor.
+  Metrics: full M03 short-summary set restricted to HPV16 (total
+  infections, total cancers, total cancer deaths, mean HPV prevalence,
+  mean cancer incidence, mean ages of infection / cancer / cancer death,
+  total population). Threshold `|z| < 3`.
+
+Both tests call `parity_gate(...)` and `pytest.fail(...)` listing any
+failing metrics.
+
+### Existing M01 / M02 tests
+
+`test_partnership_equivalence.py`, `test_natural_history.py`, and the rest
+of the single-seed M01/M02 smoke tests are not modified. They keep their
+fast-smoke role; the new multi-seed tests become the new acceptance gates.
+
+### Partnership-network metrics
+
+`test_partnership_equivalence.py`'s categorical/distributional metrics
+(`n_pairs`, `mean_dur`, `concurrency_max`, `mixing-cosine`) remain in their
+current single-seed form. They are not means-with-computable-SEs, so the
+z-score formulation does not apply. Tightening their thresholds is tracked
+as the separate M02-followup issue (MIGRATION_PLAN line 131).
+
+---
+
+## Demo: vx-coverage sweep
+
+### File
+
+`examples/m07_uq_sweep.py` (~120 LOC).
+
+### Configuration
+
+Reuses M05's Nigeria 4-genotype anchor (`tests/regression/anchor_vx_routine.py:PARS`)
+so the demo introduces no new calibration target — it shows how validated M05
+machinery extends to UQ + scenario sweep.
+
+### Sweep grid
+
+4 coverage levels × 20 seeds = 80 sims total.
+
+- Coverage levels ∈ `{0.0, 0.3, 0.6, 0.9}` — passed as the `prob` kwarg on
+  `hpv.routine_vx` (which forwards to `ss.RoutineDelivery.prob`).
+- `rand_seed ∈ range(20)`
+- The 0-coverage baseline is realized by setting `prob=0.0` on the
+  intervention rather than by dropping the intervention. The sim-construction
+  path is identical across the four scenarios; the only difference is the
+  `prob` scalar. This keeps the RNG stream cleanly comparable across
+  scenarios.
+
+### Script shape
+
+```python
+import sciris as sc
+import starsim as ss
+import hpvsim as hpv
+from tests.regression.anchor_vx_routine import PARS as VX_PARS
+
+COVERAGES = [0.0, 0.3, 0.6, 0.9]
+N_SEEDS = 20
+
+def make_sim(seed, coverage):
+    kwargs = sc.dcp(VX_PARS)
+    kwargs['rand_seed'] = seed
+    kwargs['label'] = f'coverage={coverage:.0%}'
+    kwargs['interventions'] = [hpv.routine_vx(
+        product='bivalent', prob=coverage, age_range=(9, 14), sex='f',
+    )]
+    return hpv.Sim(**kwargs)
+
+if __name__ == '__main__':
+    iterkwargs = [dict(seed=s, coverage=c)
+                  for c in COVERAGES for s in range(N_SEEDS)]
+    sims = sc.parallelize(make_sim, iterkwargs=iterkwargs)
+    msim = ss.parallel(*sims)
+
+    by_cov = {c: ss.MultiSim([s for s in msim.sims
+                              if s.label == f'coverage={c:.0%}'])
+              for c in COVERAGES}
+    for sub_msim in by_cov.values():
+        sub_msim.median()
+
+    _plot_coverage_sweep(by_cov)
+    sc.savefig('m07_uq_sweep.png')
+```
+
+### Why this exercises every M07 sub-task
+
+- `sc.parallelize(make_sim, ...)` exercises parallel sim *creation*.
+- `ss.parallel(*sims)` exercises parallel sim *execution* across seeds and
+  scenarios.
+- `ss.MultiSim([...]).median()` exercises result reduction (median + 10/90
+  quantiles).
+- The `make_sim(seed, coverage)` factory pattern *is* the documented
+  Starsim-native replacement for v2's `Scenarios` — this script becomes
+  the canonical reference in the tutorial.
+
+### Tutorial section
+
+`docs/tutorials/tut_running.qmd` is edited to:
+
+- Replace the v2 `hpv.Scenarios` example currently embedded there with a
+  condensed walk-through of `m07_uq_sweep.py`.
+- Add a short "Migrating from v2 Scenarios" subsection mapping
+  `hpv.Scenarios(scenarios={'low': {...}, 'high': {...}})` → labeled sims +
+  `ss.parallel`.
+
+### CI cost
+
+The demo script itself is not in the test suite — runtime is too long. The
+smoke variant `tests/test_m07_demo_smoke.py` (1 coverage × 2 seeds) covers
+the example surface so it doesn't bit-rot.
+
+---
+
+## Random-seed semantics
+
+This section pins down the seed semantics M07 depends on. They are Starsim
+defaults; M07 verifies them rather than implementing them.
+
+- **Single sim.** `hpv.Sim(rand_seed=k)` is reproducible bit-for-bit on
+  identical inputs. Already established by M03's parity gates; M07 changes
+  nothing.
+- **Replicate runs.** `ss.MultiSim(sim, n_runs=N).run()` assigns
+  `rand_seed = base_seed + i` to the i-th replicate, where `base_seed`
+  defaults to `sim.pars.rand_seed`. Verified in
+  `test_m07_multisim::test_multisim_n_runs` by asserting replicate `i`
+  matches a freshly-constructed `hpv.Sim(rand_seed=base_seed + i)`.
+- **Scenario comparison.** `ss.parallel(s1, s2, ...)` honors each sim's
+  `rand_seed` verbatim — no auto-stepping. Two sims with the same explicit
+  `rand_seed` produce identical RNG streams; this is the property
+  `test_parallel_seed_reproducibility` exercises.
+- **Cross-scenario CRN.** When `make_sim(seed, scenario)` builds N sims per
+  scenario sharing the same `seed` set, the same seed across scenarios
+  drives correlated streams (paired-seed CRN for variance reduction). M07
+  covers the same-seed-same-sim case directly; full CRN-across-scenarios
+  audit is a tracking-issue follow-up.
+
+**Nuance worth a docstring, not a test.** Starsim's CRN guarantee holds at
+the *distribution-call level*, not the *simulation-step level*. Adding or
+removing an `ss.Bernoulli` draw in one variant shifts all downstream draws.
+The verification tests' docstrings note this so future maintainers don't
+expect bit-equality after adding new modules.
+
+---
+
+## Testing & CI
+
+### New tests
+
+| File | LOC | Markers | Purpose |
+|---|---:|---|---|
+| `tests/test_m07_multisim.py` | ~80 | fast | n_runs distinctness, median/mean shape, label propagation |
+| `tests/test_m07_parallel.py` | ~80 | fast | seed reproducibility, separation, inplace, copy_inputs |
+| `tests/test_m07_demo_smoke.py` | ~30 | fast | tiny variant of the demo |
+| `tests/test_m01_short_summary_parity.py` | ~120 | slow | 30-seed z-score gate vs v2 M01 baseline |
+| `tests/test_m02_short_summary_parity.py` | ~120 | slow | 30-seed z-score gate vs v2 M02 baseline |
+
+### New helpers / data
+
+| File | LOC | Purpose |
+|---|---:|---|
+| `tests/regression/parity.py` | ~80 | shared `parity_gate()` |
+| `tests/regression/anchor_m01.py` | ~40 | M01 anchor PARS dict |
+| `tests/regression/anchor_m02.py` | ~40 | M02 anchor PARS dict |
+
+### Existing files edited
+
+- `tests/regression/multi_seed_v2.py` — add `--anchor m01|m02` flag.
+  Backward-compatible.
+- `tests/regression/README.md` — document the two new anchors + their
+  baseline regeneration.
+- `docs/tutorials/tut_running.qmd` — replace `Scenarios` section.
+- `MIGRATION_PLAN.md` — M07 sub-task list edited to reflect actual scope.
+
+### Existing files NOT touched
+
+- `test_m03_*_parity.py`, `test_m05_vx_*_parity.py` — left alone.
+- `test_partnership_equivalence.py`, `test_natural_history.py`, etc. — left
+  alone.
+
+### CI
+
+- Fast jobs (default) pick up the three new fast tests automatically;
+  combined added wall-clock < 60 s.
+- Slow job (existing `@pytest.mark.slow` selection) picks up the two new
+  parity tests. No new CI configuration needed.
+
+---
+
+## Acceptance criteria
+
+M07 is done when:
+
+1. All new tests pass locally and in CI.
+2. `examples/m07_uq_sweep.py` runs end-to-end on developer hardware and
+   produces the cancer-incidence-by-age figure (`m07_uq_sweep.png`).
+3. `tests/regression/v2_m01_seeds_n30.json` and `v2_m02_seeds_n30.json` are
+   regeneratable from a v2-hpvsim env via `multi_seed_v2.py --anchor m0X`.
+4. `docs/tutorials/tut_running.qmd` updated; no `hpv.Scenarios` or
+   `hpv.Sweep` references remain in active docs or examples.
+5. `MIGRATION_PLAN.md` M07 sub-task list edited to:
+   - Drop "Port the `Scenarios` class for parameter sweeps and intervention comparisons."
+   - Drop "Port the `Sweep` class for systematic parameter variation."
+   - Keep "Verify `ss.MultiSim` works with `hpv.Sim`."
+   - Keep "Verify `ss.parallel()` works with proper random-seed handling."
+   - Replace the M1–M6 re-run bullet with "Retrofit M01/M02 acceptance tests to multi-seed z-score gates matching the M03 standard; M03/M05 already pass; M04/M06 own their own UQ."
+   - Add "Demo: vx-coverage sweep example (`examples/m07_uq_sweep.py`) + tutorial-section rewrite."
+
+## Tracking issues opened during M07 (followups, not gating)
+
+- **Refactor M03/M05 parity tests onto `parity_gate()` helper.** Code
+  dedup, no behavior change.
+- **Update validation repos (`hpvsim_methods_manuscript`, etc.) to drop
+  `hpv.Scenarios` imports.** Coordinated with Robyn per RACI.
+- **Tighten partnership-network parity beyond M01 single-seed thresholds.**
+  Distinct from M07; remains an M02-followup issue.
+- **Audit cross-scenario CRN across truly different parameter values.**
+  Out of M07 scope; covered narrowly by M07's same-seed-same-sim test.
+
+## Risks
+
+- **`test_parallel_seed_reproducibility` flake.** Most likely failure mode
+  is subtle Starsim RNG in-place state across `ss.parallel` workers.
+  Mitigation: fresh `hpv.Sim` per test (no `sc.dcp`); explicit
+  `copy_inputs=True` for all comparison sims; if it flakes, root-cause
+  rather than relax.
+- **v2-baseline drift between regenerations.** Mitigation: lock
+  `tests/_legacy/requirements.txt` to the exact v2 release used for M03
+  baseline regen; document the lock in the README. (This is an existing
+  risk for M03/M05; M07 just inherits it.)
+
+## References
+
+- Starsim multi-sim docs: `starsim-dev-run` skill (Starsim 3.3.4).
+- M03 design: [`2026-05-06-m03-multi-genotype-cross-immunity-design.md`](./2026-05-06-m03-multi-genotype-cross-immunity-design.md).
+- M05 design: [`2026-05-20-m05-vaccination-scenarios-design.md`](./2026-05-20-m05-vaccination-scenarios-design.md).
+- `MIGRATION_PLAN.md` — milestone definitions and conventions.

--- a/docs/superpowers/specs/2026-05-27-m07-multisim-design.md
+++ b/docs/superpowers/specs/2026-05-27-m07-multisim-design.md
@@ -2,24 +2,28 @@
 
 **Date:** 2026-05-27
 **Milestone:** M07 (MultiSim and scenarios)
-**Branch:** `m07-multisim` (off `m05-vaccination-scenarios`; PR targets `v3.0-dev`)
-**Predecessor:** [M05 Vaccination Scenarios](2026-05-20-m05-vaccination-scenarios-design.md)
-**Status:** Design — not yet implemented.
+**Branch:** `m07-multisim` (off `m06-test-and-treat-cascade`; PR targets `v3.0-dev`)
+**Predecessor:** [M06 Test-and-Treat Cascade](2026-05-27-m06-test-and-treat-cascade-design.md) — and via M06, M05's vaccination work the demo depends on.
+**Status:** Implementation complete; rebased onto `m06-test-and-treat-cascade` 2026-05-28.
 
 ## Dependencies and rebase strategy
 
-M07 branches off `m05-vaccination-scenarios` rather than `v3.0-dev` because
-the demo (`examples/m07_uq_sweep.py`) and its smoke test
+M07 originally branched off `m05-vaccination-scenarios` because the demo
+(`examples/m07_uq_sweep.py`) and its smoke test
 (`tests/test_m07_demo_smoke.py`) consume M05 deliverables: `hpv.routine_vx`,
 `hpv.vx`, the Nigeria 4-genotype vaccination anchor at
 `tests/regression/anchor_vx_routine.py`, and `products_vx.csv`. The
 verification tests (`test_m07_multisim.py`, `test_m07_parallel.py`) and the
 M01/M02 parity-gate tests do not depend on M05.
 
-Once M05 merges to `v3.0-dev`, this branch rebases onto `v3.0-dev` and the
-M07 PR targets `v3.0-dev` directly. If M07 finishes implementation before
-M05 merges, the PR is held in draft against `v3.0-dev` with M05's diff
-visible until M05 lands. (Same pattern as M03, which branched off
+After implementation completed (2026-05-28), the branch was rebased onto
+`m06-test-and-treat-cascade` rather than waiting for M05 to merge to
+`v3.0-dev`. M06's history includes M05's tip plus the M06 work, so the M05
+deliverables M07 depends on are reachable through the M06 base. The M07
+PR targets `v3.0-dev` directly and is held in draft until M05 and M06 land
+on `v3.0-dev`, after which M07 either merges cleanly (if no conflicting
+edits to `MIGRATION_PLAN.md` etc. land between) or rebases once more onto
+the updated `v3.0-dev`. (Conceptually similar to M03, which branched off
 `m02-natural-history-parity` and rebased onto `v3.0-dev` after M02 merged.)
 
 ---
@@ -500,4 +504,5 @@ M07 is done when:
 - Starsim multi-sim docs: `starsim-dev-run` skill (Starsim 3.3.4).
 - M03 design: [`2026-05-06-m03-multi-genotype-cross-immunity-design.md`](./2026-05-06-m03-multi-genotype-cross-immunity-design.md).
 - M05 design: [`2026-05-20-m05-vaccination-scenarios-design.md`](./2026-05-20-m05-vaccination-scenarios-design.md).
+- M06 design: [`2026-05-27-m06-test-and-treat-cascade-design.md`](./2026-05-27-m06-test-and-treat-cascade-design.md) — current base branch.
 - `MIGRATION_PLAN.md` — milestone definitions and conventions.

--- a/docs/tutorials/tut_running.qmd
+++ b/docs/tutorials/tut_running.qmd
@@ -60,14 +60,15 @@ msim.plot()
 ```
 
 Note that `.median()` and `.mean()` **mutate** the MultiSim in place. Prefer
-`.median()` for bounded metrics (cancers, infections, prevalence) — mean ± 2 SD
-can produce non-physical lower bounds.
+`.median()` for metrics like cancers, infections, and prevalence: these are
+rarely normally distributed across seeds, so a mean ± 2 SD band is not a true
+95% CI and its lower edge can fall below zero.
 
 ### Comparing scenarios
 
-For scenario comparisons, use a `make_sim(seed, scenario)` factory function
-and pass the labeled sims to `ss.parallel`. This is the Starsim-native
-replacement for v2's `hpv.Scenarios`:
+For scenario comparisons, write a `make_sim(seed, scenario)` function that
+builds one sim per scenario, and pass the labeled sims to `ss.parallel`. This
+is the Starsim-native replacement for v2's `hpv.Scenarios`:
 
 ```{python}
 import hpvsim as hpv
@@ -83,7 +84,7 @@ PARS = dict(
 )
 
 def make_sim(seed, coverage):
-    """Factory: one sim per (seed, coverage) point."""
+    """Make a sim for a given random seed and coverage level."""
     return hpv.Sim(
         **PARS,
         rand_seed=seed,
@@ -177,7 +178,7 @@ each `s` in `sims` has already been run), the objects are the same.
 
 | v2 pattern | v3 replacement |
 |---|---|
-| `hpv.Scenarios(scenarios={'low': {...}, 'high': {...}})` | `make_sim(seed, scenario)` factory + `ss.parallel(*sims)` |
+| `hpv.Scenarios(scenarios={'low': {...}, 'high': {...}})` | `make_sim(seed, scenario)` + `ss.parallel(*sims)` |
 | `scens.run()` | `ss.parallel(*sims)` |
 | `scens.results['low']` | filter `msim.sims` by label, wrap in `ss.MultiSim` |
 | `hpv.MultiSim(sim, n_runs=N)` | `ss.MultiSim(sim, n_runs=N)` (same name in Starsim) |

--- a/docs/tutorials/tut_running.qmd
+++ b/docs/tutorials/tut_running.qmd
@@ -8,166 +8,181 @@ While running individual sims can be interesting for simple explorations, at som
 
 
 <div class="alert alert-info">
-    
+
 Click [here](https://mybinder.org/v2/gh/institutefordiseasemodeling/hpvsim/HEAD?urlpath=lab%2Ftree%2Fdocs%2Ftutorials%2Ftut_running.ipynb) to open an interactive version of this notebook.
-    
+
 </div>
 
-## Running with MultiSims
+## Multi-seed runs and scenario sweeps
 
-The most common way to run multiple simulations is with the *MultiSim* object. As the name suggests, this is a relatively simple container for a number of sims. However, it contains powerful methods for plotting, statistics, and running all the sims in parallel.
+HPVsim v3 uses Starsim's native multi-sim machinery — `ss.MultiSim`,
+`ss.parallel`, and Sciris's `sc.parallelize` — for replicate runs,
+scenario comparisons, and parameter sweeps. v2's `hpv.Scenarios` class
+has been removed; the pattern below is the Starsim-native replacement.
 
-### Running one sim with uncertainty
+### Replicate runs (multi-seed UQ)
 
-Making and running a multisim based on a single sim is pretty easy:
+Making and running a MultiSim based on a single sim is straightforward.
+Passing `n_runs=N` automatically creates N copies of the sim with
+different random seeds:
 
 ```{python}
 import hpvsim as hpv
-hpv.options(jupyter=True, verbose=0)
+import starsim as ss
 
-sim = hpv.Sim()
-msim = hpv.MultiSim(sim)
-msim.run(n_runs=5)
-msim.plot();
+sim = hpv.Sim(
+    n_agents=10_000,
+    location='nigeria',
+    genotypes=[16, 18, 'hi5', 'ohr'],
+    start=1990,
+    stop=2030,
+    verbose=0,
+)
+msim = ss.MultiSim(sim, n_runs=5)
+msim.run(verbose=0)
+msim.plot()
 ```
 
-If you run a multisim with a single sim input as above, it will change the random seed for each sim, which is what leads to the variability you see.
-
-By default, the multisim simply plots each simulation. These simulations are stored in the `sims` attribute, which is just a simple list of sims:
+The individual sim results are stored in `msim.sims`. You can inspect them directly:
 
 ```{python}
-for sim in msim.sims:
-    sim.brief()
+for s in msim.sims:
+    s.brief()
 ```
 
-However, you often don't care about the individual sims (especially when you run the same parameters with different random seeds); you want to see the *statistics* for the sims. You can calculate either the mean or the median of the results across all the sims as follows:
+Often you care about *statistics* across seeds rather than individual runs. Call
+`.median()` or `.mean()` to reduce the MultiSim in place and expose quantile
+ribbons in plots:
 
 ```{python}
-msim.mean()
-msim.plot('infections');
+msim.median()   # mutates msim in place; computes median + 10/90 quantiles
+msim.plot()
 ```
 
-```{python}
-msim.median()
-msim.plot('infections');
-```
+Note that `.median()` and `.mean()` **mutate** the MultiSim in place. Prefer
+`.median()` for bounded metrics (cancers, infections, prevalence) — mean ± 2 SD
+can produce non-physical lower bounds.
 
-You can see these are similar, but slightly different. You can also treat each of the individual sims as part of a larger single sim, and "combine" the results into one sim:
+### Comparing scenarios
 
-```{python}
-msim.combine()
-msim.plot('infections');
-```
-
-Note how now there is no uncertainty and the total number of infections is 5x higher than in the previous plots, since we just added 5 different sims together.
-
-Each of these operations modifies the `msim.base_sim` object, and does not affect the actual list of stored sims, which is why you can go back and forth between them.
-
-### Running different sims
-
-Often you don't want to run the same sim with different seeds, but instead want to run a set of different sims. That's also very easy -- for example, here's how you would do a sweep across relative transmissibility of HPV:
+For scenario comparisons, use a `make_sim(seed, scenario)` factory function
+and pass the labeled sims to `ss.parallel`. This is the Starsim-native
+replacement for v2's `hpv.Scenarios`:
 
 ```{python}
-#| collapsed: false
-#| pycharm: {name: "#%%\n"}
-import numpy as np
+import hpvsim as hpv
+import starsim as ss
 
-rel_trans_vals = np.linspace(0.1, 0.8, 5) # Sweep from 0.5 to 1.5 with 5 values
-sims = []
-for rel_trans in rel_trans_vals:
-    sim = hpv.Sim(beta=rel_trans, label=f'Rel trans HPV = {rel_trans}')
-    sims.append(sim)
-msim = hpv.MultiSim(sims)
-msim.run()
-msim.plot('infections');
-```
-
-As you would expect, the more transmissible people with HPV are, the more infections we get.
-
-Finally, note that you can use multisims to do very compact scenario explorations -- here we are using the command `hpv.parallel()`, which is an alias for `hpv.MultiSim().run()`:
-
-```{python}
-def custom_vx(sim):
-    if sim.yearvec[sim.t] == 2000:
-        target_group = (sim.people.age>9) * (sim.people.age<14)
-        sim.people.peak_imm[0, target_group] = 1
-
-pars = dict(
-    location = 'tanzania', # Use population characteristics for Japan
-    n_agents = 10e3, # Have 50,000 people total in the population
-    start = 1980, # Start the simulation in 1980
-    n_years = 50, # Run the simulation for 50 years
-    burnin = 10, # Discard the first 20 years as burnin period
-    verbose = 0, # Do not print any output
+PARS = dict(
+    n_agents=10_000,
+    location='nigeria',
+    genotypes=[16, 18, 'hi5', 'ohr'],
+    start=1990,
+    stop=2030,
+    verbose=0,
 )
 
-# Running with multisims -- see Tutorial 3
-s1 = hpv.Sim(pars, label='Default')
-s2 = hpv.Sim(pars, interventions=custom_vx, label='Custom vaccination')
-hpv.parallel(s1, s2).plot(['hpv_incidence', 'cancer_incidence']);
+def make_sim(seed, coverage):
+    """Factory: one sim per (seed, coverage) point."""
+    return hpv.Sim(
+        **PARS,
+        rand_seed=seed,
+        label=f'coverage={coverage:.0%}',
+        interventions=[hpv.routine_vx(
+            product='bivalent',
+            prob=float(coverage),
+            age_range=[9, 14],
+            sex='f',
+            start_year=2010,
+        )],
+    )
+
+sims = [make_sim(seed=0, coverage=c) for c in [0.0, 0.3, 0.6, 0.9]]
+msim = ss.parallel(*sims, verbose=0)
+msim.plot()
 ```
+
+As expected, higher vaccination coverage leads to fewer HPV infections and
+cancers over time.
+
+### Sweeping parameters with multi-seed UQ
+
+Combine both techniques: build a grid of (coverage, seed) pairs in a list
+comprehension, run all sims with `ss.parallel`, then group results by scenario
+for per-scenario median reduction:
+
+```{python}
+import hpvsim as hpv
+import starsim as ss
+
+PARS = dict(
+    n_agents=10_000,
+    location='nigeria',
+    genotypes=[16, 18, 'hi5', 'ohr'],
+    start=1990,
+    stop=2030,
+    verbose=0,
+)
+
+def make_sim(seed, coverage):
+    return hpv.Sim(
+        **PARS,
+        rand_seed=seed,
+        label=f'coverage={coverage:.0%}',
+        interventions=[hpv.routine_vx(
+            product='bivalent',
+            prob=float(coverage),
+            age_range=[9, 14],
+            sex='f',
+            start_year=2010,
+        )],
+    )
+
+COVERAGES = [0.0, 0.3, 0.6, 0.9]
+N_SEEDS = 10
+
+# Build all sims up front, then run in one parallel batch
+sims = [make_sim(seed=s, coverage=c)
+        for c in COVERAGES for s in range(N_SEEDS)]
+msim = ss.parallel(*sims, verbose=0)
+
+# Group by scenario label and reduce each group independently
+by_cov = {}
+for cov in COVERAGES:
+    sub = ss.MultiSim([s for s in msim.sims
+                       if s.label.startswith(f'coverage={cov:.0%}')])
+    sub.median()
+    by_cov[cov] = sub
+```
+
+For large grids (hundreds of sims), replace the list comprehension with
+`sc.parallelize` for parallel sim *creation* as well as parallel execution.
+Because `sc.parallelize` uses multiprocessing, `make_sim` must be defined at
+module level (not inside a notebook cell), and the call must be protected with
+`if __name__ == '__main__':`. A full worked example using `sc.parallelize` is
+in `examples/m07_uq_sweep.py`.
 
 <div class="alert alert-warning">
 
-**Warning:** Because `multiprocess` pickles the sims when running them, `sims[0]` (before being run by the multisim) and `msim.sims[0]` are **not** the same object. After calling `msim.run()`, always use sims from the multisim object, not from before. In contrast, if you *don't* run the multisim (e.g. if you make a multisim from already-run sims), then `sims[0]` and `msim.sims[0]` are indeed exactly the same object.
+**Warning:** Because `multiprocess` pickles the sims when running them,
+`sims[i]` (before being run) and `msim.sims[i]` are **not** the same object.
+After calling `ss.parallel(...)` or `msim.run()`, always retrieve sims from
+the MultiSim object (`msim.sims`), not from the original list. Conversely, if
+you construct a MultiSim from *already-run* sims (e.g. `ss.MultiSim(sims)` where
+each `s` in `sims` has already been run), the objects are the same.
 
 </div>
 
-### Advanced usage
+### Migrating from v2's `hpv.Scenarios`
 
-Finally, you can also merge or split different multisims together. Here's an example that's similar to before, except it shows how to run a multisim of different seeds for the same `rel_trans` value, but then merge multisims for different `rel_trans` values together into one multisim:
+| v2 pattern | v3 replacement |
+|---|---|
+| `hpv.Scenarios(scenarios={'low': {...}, 'high': {...}})` | `make_sim(seed, scenario)` factory + `ss.parallel(*sims)` |
+| `scens.run()` | `ss.parallel(*sims)` |
+| `scens.results['low']` | filter `msim.sims` by label, wrap in `ss.MultiSim` |
+| `hpv.MultiSim(sim, n_runs=N)` | `ss.MultiSim(sim, n_runs=N)` (same name in Starsim) |
+| `hpv.parallel(s1, s2)` | `ss.parallel(s1, s2)` (same name in Starsim) |
+| `hpv.MultiSim.merge(msims)` | combine sim lists with `+` and re-wrap: `ss.MultiSim(msim1.sims + msim2.sims)` |
 
-```{python}
-n_sims = 3
-rel_trans_vals = [0.25, 0.5, 0.75]
-
-msims = []
-for rel_trans in rel_trans_vals:
-    sims = []
-    for s in range(n_sims):
-        sim = hpv.Sim(n_agents=10e3, beta=rel_trans, rand_seed=s, label=f'Rel trans = {rel_trans}')
-        sims.append(sim)
-    msim = hpv.MultiSim(sims)
-    msim.run()
-    msim.mean()
-    msims.append(msim)
-
-merged = hpv.MultiSim.merge(msims, base=True)
-merged.plot(color_by_sim=True);
-```
-
-As you can see, running this way lets you run not just different values, but run different values with uncertainty. Which brings us to...
-
-## Running with Scenarios
-
-Most of the time, you'll want to run with multisims since they give you the most flexibility. However, in certain cases, Scenario objects let you achieve the same thing more simply. Unlike MultiSims, which are completely agnostic about what sims you include, scenarios always start from the same base sim. They then modify the parameters as you specify, and finally add uncertainty, if desired. For example, this shows how you'd use scenarios to run the example similar to the one above.
-
-```{python}
-# Set base parameters -- these will be shared across all scenarios
-basepars = {'n_agents':10e3} 
-
-# Configure the settings for each scenario
-scenarios = {'baseline': {
-              'name':'Baseline',
-              'pars': {}
-              },
-            'high_rel_trans': {
-              'name':'High rel trans (0.75)',
-              'pars': {
-                  'beta': 0.75,
-                  }
-              },
-            'low_rel_trans': {
-              'name':'Low rel trans(0.25)',
-              'pars': {
-                  'beta': 0.25,
-                  }
-              },
-             }
-
-# Run and plot the scenarios
-scens = hpv.Scenarios(basepars=basepars, scenarios=scenarios)
-scens.run()
-scens.plot();
-```
-
+A full worked example — 4 × 20 (coverage × seed) routine-vx sweep with
+median + 10/90 quantile cancer plots — lives in `examples/m07_uq_sweep.py`.

--- a/examples/m07_uq_sweep.py
+++ b/examples/m07_uq_sweep.py
@@ -14,7 +14,7 @@ Exercises every M07 verification target:
 Run from the repo root:
     python examples/m07_uq_sweep.py
 Produces:
-    m07_uq_sweep.png  (cancer trajectories by coverage, with CIs)
+    m07_uq_sweep.png  (cumulative cancers by coverage, with CIs)
 """
 import argparse
 from pathlib import Path
@@ -93,9 +93,8 @@ def _plot_coverage_sweep(by_cov, out_png):
         # are flattened to top-level keys after .median().
         # Try a few candidate result keys to be robust to API drift.
         candidates = [
-            'hpvtotal_new_cancers',
             'hpvtotal_cum_cancers',
-            'hpv16_new_cancers',  # fallback: per-genotype if aggregate absent
+            'hpv16_cum_cancers',
         ]
         result_key = next(
             (k for k in candidates if hasattr(sub_msim.results, k)), None
@@ -120,8 +119,8 @@ def _plot_coverage_sweep(by_cov, out_png):
         line, = ax.plot(years, median, label=f'coverage={cov:.0%}')
         ax.fill_between(years, lo, hi, alpha=0.2, color=line.get_color())
     ax.set_xlabel('Year')
-    ax.set_ylabel('New cancers (per step)')
-    ax.set_title('Cancer trajectories by routine-vx coverage (median + 10/90)')
+    ax.set_ylabel('Cumulative cancers')
+    ax.set_title('Cumulative cancers by routine-vx coverage (median + 10/90)')
     ax.legend()
     fig.tight_layout()
     fig.savefig(out_png, dpi=150)

--- a/examples/m07_uq_sweep.py
+++ b/examples/m07_uq_sweep.py
@@ -1,0 +1,135 @@
+"""M07 demo: vaccination-coverage sweep with multi-seed UQ.
+
+Runs a 4 × 20 (coverage × seed) routine-vx sweep on the M05 Nigeria
+4-genotype anchor, reduces each coverage scenario to median + 10/90
+quantiles, and plots aggregate cancer trajectories by coverage.
+
+Exercises every M07 verification target:
+  - sc.parallelize for parallel sim CREATION
+  - ss.parallel for parallel sim EXECUTION
+  - ss.MultiSim.median for result REDUCTION
+  - make_sim(seed, coverage) is the Starsim-native replacement for v2's
+    hpv.Scenarios.
+
+Run from the repo root:
+    python examples/m07_uq_sweep.py
+Produces:
+    m07_uq_sweep.png  (cancer trajectories by coverage, with CIs)
+"""
+import argparse
+from pathlib import Path
+
+import numpy as np
+import sciris as sc
+import starsim as ss
+import hpvsim as hpv
+
+from tests.regression.anchor_vx_routine import PARS as VX_PARS
+
+
+COVERAGES = [0.0, 0.3, 0.6, 0.9]
+N_SEEDS = 20
+
+
+def make_sim(seed, coverage):
+    """Build one sim for the (seed, coverage) point.
+
+    Mirrors M05's anchor PARS but builds a fresh hpv.routine_vx with the
+    swept coverage. The M05 PARS field `intervention` (a serializable
+    config dict) is NOT forwarded as a kwarg — we build the intervention
+    explicitly here.
+
+    Sim deep-copies inputs at __init__, so post-run inspection must go
+    through sim.interventions, not the local reference.
+    """
+    return hpv.Sim(
+        location=VX_PARS.location,
+        start=VX_PARS.start,
+        stop=VX_PARS.stop,
+        rand_seed=int(seed),
+        n_agents=VX_PARS.n_agents,
+        genotypes=list(VX_PARS.genotypes),
+        v2_compat_demographics=VX_PARS.v2_compat_demographics,
+        verbose=0,
+        label=f'coverage={coverage:.0%}|seed={seed}',
+        interventions=[hpv.routine_vx(
+            product='bivalent',
+            prob=float(coverage),
+            age_range=[9, 10],
+            sex='f',
+            start_year=2020,
+            name='routine_bivalent_girls',
+        )],
+    )
+
+
+def main(out_png=Path('m07_uq_sweep.png')):
+    iterkwargs = [dict(seed=s, coverage=c)
+                  for c in COVERAGES for s in range(N_SEEDS)]
+    print(f'Building {len(iterkwargs)} sims via sc.parallelize...')
+    sims = sc.parallelize(make_sim, iterkwargs=iterkwargs)
+
+    print(f'Running {len(sims)} sims via ss.parallel...')
+    msim = ss.parallel(*sims, verbose=0)
+
+    # Group sims back into per-coverage MultiSims for reduction.
+    by_cov = {}
+    for cov in COVERAGES:
+        tag = f'coverage={cov:.0%}'
+        cov_sims = [s for s in msim.sims if s.label.startswith(tag)]
+        sub = ss.MultiSim(cov_sims)
+        sub.median()
+        by_cov[cov] = sub
+
+    _plot_coverage_sweep(by_cov, out_png)
+    print(f'Wrote {out_png}')
+
+
+def _plot_coverage_sweep(by_cov, out_png):
+    import matplotlib.pyplot as plt
+    fig, ax = plt.subplots(figsize=(8, 5))
+    for cov, sub_msim in by_cov.items():
+        # The HPVTotal analyzer aggregates per-genotype cancers; results
+        # are flattened to top-level keys after .median().
+        # Try a few candidate result keys to be robust to API drift.
+        candidates = [
+            'hpvtotal_new_cancers',
+            'hpvtotal_cum_cancers',
+            'hpv16_new_cancers',  # fallback: per-genotype if aggregate absent
+        ]
+        result_key = next(
+            (k for k in candidates if hasattr(sub_msim.results, k)), None
+        )
+        if result_key is None:
+            raise RuntimeError(
+                f'No expected result key found on reduced msim. '
+                f'Tried {candidates}. Available keys: '
+                f'{list(sub_msim.results.keys())[:20]}'
+            )
+        res = getattr(sub_msim.results, result_key)
+        tv = sub_msim.sims[0].t.timevec
+        # Convert ss.date objects to float years (Starsim 3.x timevec
+        # contains ss.date — see starsim-dev-time skill).
+        if hasattr(tv[0], 'years'):
+            years = np.array([float(y.years) for y in tv])
+        else:
+            years = np.asarray(tv, dtype=float)
+        median = np.asarray(res)
+        lo = np.asarray(getattr(res, 'low', median))
+        hi = np.asarray(getattr(res, 'high', median))
+        line, = ax.plot(years, median, label=f'coverage={cov:.0%}')
+        ax.fill_between(years, lo, hi, alpha=0.2, color=line.get_color())
+    ax.set_xlabel('Year')
+    ax.set_ylabel('New cancers (per step)')
+    ax.set_title('Cancer trajectories by routine-vx coverage (median + 10/90)')
+    ax.legend()
+    fig.tight_layout()
+    fig.savefig(out_png, dpi=150)
+    plt.close(fig)
+
+
+if __name__ == '__main__':
+    p = argparse.ArgumentParser()
+    p.add_argument('--out', type=Path, default=Path('m07_uq_sweep.png'))
+    args = p.parse_args()
+    main(out_png=args.out)

--- a/tests/regression/README.md
+++ b/tests/regression/README.md
@@ -351,3 +351,65 @@ print(f'Wrote m02_age_cancer.json with {len(arr)} age bands')
 The output shape must match `(n_bins,)` and use the same 5-yr age bins as
 `hpv.AgeResults` defaults (0, 5, 10, ..., 100, so 21 bins total). The file
 is gitignored.
+
+---
+
+## M07 multi-seed anchors and baseline regeneration
+
+M07 adds two additional milestone anchors with multi-seed parity gates,
+mirroring M03's pattern but for the M01 (transmission-only HPV16) and M02
+(full HPV16 natural history) milestones. **The naming convention follows
+the canonical MIGRATION_PLAN milestones**:
+
+| Anchor | PARS file | Summary builder | v2 baseline (gitignored) | v2 regen command |
+|---|---|---|---|---|
+| M01 | `anchor_m01.py` | `short_summary_m01.py::build_summary_m01` | `v2_m01_seeds_n30.json` | `python tests/regression/multi_seed_v2.py --anchor m01 --n 30` |
+| M02 | `anchor_m02.py` | `short_summary.py::build_summary` (genotypes=`('hpv16',)`) | `v2_m02_seeds_n30.json` | `python tests/regression/multi_seed_v2.py --anchor m02 --n 30` |
+| M03 (4-genotype) | `anchor_4genotype.py` | `short_summary.py::build_summary` | `v2_seeds_n30.json` | `python tests/regression/multi_seed_v2.py --anchor m03_4genotype --n 30` |
+| M05 vx routine | `anchor_vx_routine.py` | (see M05 spec) | `v2_vx_routine_seeds_n30.json` | (see M05 docs) |
+| M05 vx campaign | `anchor_vx_campaign.py` | (see M05 spec) | `v2_vx_campaign_seeds_n30.json` | (see M05 docs) |
+
+### Naming-convention note
+
+The earlier "M01 1-genotype baseline" section above documents
+`anchor_hpv16.py` under legacy terminology. Under the current MIGRATION_PLAN
+naming, that file corresponds to M02 (full HPV16 natural history). The
+new M07 anchors (`anchor_m01.py` and `anchor_m02.py`) use the current
+naming. Both sets of anchor files coexist — workflows depending on the
+legacy `anchor_hpv16.py` continue to work.
+
+### Regenerating from a v2 env
+
+The baseline regen scripts run under hpvsim v2.3 in a separate Python env;
+the active v3 env will not work. A local v2 env can be set up as a fresh
+worktree of `rc2.3`:
+
+```bash
+git worktree add ../hpvsim_v23_frozen rc2.3
+cd ../hpvsim_v23_frozen
+python -m venv .venv-v23
+.venv-v23/bin/pip install -e .
+```
+
+Then run, from the *v3* repo root, with the v2 env's Python:
+
+```bash
+../hpvsim_v23_frozen/.venv-v23/bin/python tests/regression/multi_seed_v2.py \
+    --anchor m01 --n 30 \
+    --out tests/regression/v2_m01_seeds_n30.json
+```
+
+(Adjust paths for Windows or your local setup.)
+
+### Parity-gate test → baseline mapping
+
+The slow parity-gate tests (marked `@pytest.mark.slow`) skip themselves
+if the corresponding baseline JSON is missing. The skip message points at
+the regen command for the specific anchor.
+
+| Pytest test | Baseline file expected |
+|---|---|
+| `test_m01_short_summary_parity.py::test_m01_short_summary_parity` | `v2_m01_seeds_n30.json` |
+| `test_m02_short_summary_parity.py::test_m02_short_summary_parity` | `v2_m02_seeds_n30.json` |
+| `test_m03_short_summary_parity.py::test_short_summary_parity_4genotype` | `v2_seeds_n30.json` |
+| (M05 vx parity tests) | (see M05 spec) |

--- a/tests/regression/anchor_m01.py
+++ b/tests/regression/anchor_m01.py
@@ -1,0 +1,48 @@
+"""M01 anchor scenario for the v2 -> v3 migration regression harness.
+
+Single-genotype HPV16, transmission only (SIS clearance, no precin/CIN/
+cancer progression). Nigeria, 1990-2030 to keep the run short while
+still spanning a credible demographic window.
+
+Pinned anchor pars. Do not change without coordinating with regression baselines.
+"""
+import sys
+from pathlib import Path
+
+import sciris as sc
+
+import hpvsim as hpv
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from short_summary_m01 import build_summary_m01  # noqa: E402
+
+
+PARS = dict(
+    n_agents=10e3,
+    location='nigeria',
+    genotypes=[16],
+    start=1990,
+    stop=2030,
+    dt=0.25,
+    rand_seed=0,
+    verbose=0,
+)
+
+
+def make_sim():
+    """Build (but do not run) the M01 anchor sim."""
+    return hpv.Sim(**sc.dcp(PARS))
+
+
+def run_and_summarize():
+    """Run the M01 anchor sim and return the short summary dict."""
+    sim = make_sim()
+    sim.run()
+    return build_summary_m01(sim)
+
+
+if __name__ == '__main__':
+    short = run_and_summarize()
+    print('Short summary (M01 HPV16 transmission-only):')
+    for k, v in short.items():
+        print(f'  {k:<40} {v:>12.4g}')

--- a/tests/regression/anchor_m02.py
+++ b/tests/regression/anchor_m02.py
@@ -1,0 +1,57 @@
+"""M02 anchor scenario: single-genotype HPV16 with full natural history.
+
+Full HPV16 progression (precin/CIN/cancer + cancer death). Nigeria,
+1990-2060 to cover the full lifetime cancer signal. This is the M02
+acceptance-test target — single-genotype, full natural history.
+
+Pinned anchor pars. Do not change without coordinating with regression baselines.
+"""
+import sys
+from pathlib import Path
+
+import sciris as sc
+
+import hpvsim as hpv
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from short_summary import build_summary  # noqa: E402
+
+
+PARS = dict(
+    n_agents=10e3,
+    location='nigeria',
+    genotypes=[16],
+    start=1990,
+    stop=2060,
+    dt=0.25,
+    rand_seed=0,
+    verbose=0,
+)
+
+GENOTYPES = ('hpv16',)
+
+
+def make_sim():
+    """Build (but do not run) the M02 anchor sim."""
+    return hpv.Sim(**sc.dcp(PARS))
+
+
+def run_and_summarize():
+    """Run the M02 anchor sim and return (short_summary_dict, total_pop).
+
+    short_summary uses the M03 builder restricted to a single genotype.
+    The output has 16 entries: 8 per-genotype (hpv16.*) + 8 aggregate (any.*).
+    """
+    sim = make_sim()
+    sim.run()
+    short = build_summary(sim, genotypes=GENOTYPES)
+    total_pop = float(sim.results['n_alive'][-1])
+    return short, total_pop
+
+
+if __name__ == '__main__':
+    short, total_pop = run_and_summarize()
+    print('Short summary (M02 HPV16 single-genotype):')
+    for k, v in short.items():
+        print(f'  {k:<48} {v:>12.4g}')
+    print(f'  {"total population":<48} {total_pop:>12.4g}')

--- a/tests/regression/baseline_v23.py
+++ b/tests/regression/baseline_v23.py
@@ -143,6 +143,56 @@ PARS_4GENOTYPE = dict(
                              # makes (1 - 0) = 1 → no reduction.
 )
 
+# ---------------------------------------------------------------------------
+# M01 — single-genotype HPV16 transmission-only anchor PARS
+# Pinned to match tests/regression/anchor_m01.py:PARS at v3, with v2's API
+# differences applied (genotypes is a list; v2 calls 'stop' -> 'end').
+# Transmission-only: we do not disable progression knobs explicitly because v2
+# does not expose a single "disable progression" toggle; the M01 v2 baseline
+# is generated with v2's default progression machinery active. The M01 summary
+# only reports infections + prevalence + total population, so the cancer
+# machinery's presence does not affect the M01 metrics.
+# ---------------------------------------------------------------------------
+
+PARS_HPV16_TRANSMISSION_ONLY = dict(
+    n_agents=10_000,
+    location='nigeria',
+    genotypes=['hpv16'],
+    start=1990,
+    end=2030,                  # v2 calls it 'end', not 'stop'
+    dt=0.25,
+    rand_seed=0,
+    verbose=0,
+    pop_scale=1,
+    total_pop=10_000,
+    ms_agent_ratio=1,
+    eff_condoms=0,
+)
+
+
+# Alias for compatibility with M07 callers that import the M02 anchor PARS
+# by its milestone-qualified name.
+PARS_HPV16 = PARS
+
+
+def _summary_v2_m01(sim, gen_idx, gen_key):
+    """v2-side M01 summary: 3 transmission-only metrics matching
+    short_summary_m01.METRIC_KEYS_M01."""
+    import numpy as np
+    res = sim.results
+    pop_scale = float(sim.pars.get('pop_scale', 1.0) or 1.0)
+    inf_arr = np.asarray(res['infections'][gen_idx, :], dtype=float)
+    n_inf = float(inf_arr.sum()) * pop_scale
+    prev_arr = np.asarray(res['hpv_prevalence'][gen_idx, :], dtype=float)
+    mean_prev_pct = 100.0 * float(prev_arr.mean())
+    total_pop = float(np.asarray(res['n_alive'])[-1])
+    return {
+        'total HPV infections': n_inf,
+        'mean HPV prevalence (%)': mean_prev_pct,
+        'total population': total_pop,
+    }
+
+
 # Canonical genotype key order that v2 stores in genotype_map after normalisation.
 # v2 parameters.py:268-273 maps '16' -> 'hpv16', 'hi5hpv' -> 'hi5', etc.
 # For these four we pass the canonical strings directly, so the genotype_map

--- a/tests/regression/baseline_v23.py
+++ b/tests/regression/baseline_v23.py
@@ -1,10 +1,10 @@
-"""Regenerate v2.3 baselines for the HPV16 (M02) and 4-genotype (M03) anchor scenarios.
+"""Regenerate v2.3 baselines for the M01 (HPV16 transmission-only), M02 (HPV16 full natural history), and M03 (4-genotype) anchor scenarios.
 
 Run this script INSIDE a Python environment that has hpvsim==2.3.x installed
 (e.g. the local hpvsim_v23_frozen clone, or a fresh `pip install hpvsim==2.3`
 venv). The v3 active package is NOT used here — only the v2.3 hpvsim API.
 
-Two regen entrypoints are provided:
+Three regen entrypoints are provided:
 
   regen_hpv16()  — M02 single-genotype HPV16 baseline (original).
                    Output: tests/regression_baselines/anchor_hpv16.json
@@ -18,6 +18,9 @@ Two regen entrypoints are provided:
                      tests/regression_baselines/anchor_4genotype_trajectory.json
                        time-series of cum_cancers and cum_infections for the
                        trajectory parity test.
+
+  M01 multi-seed baseline (no dedicated single-seed entrypoint): see
+    multi_seed_v2.py --anchor m01 --n 30 for the M07 multi-seed sweep.
 
 Key v2-vs-v3 syntax differences honored here:
   - v3 PARS uses ``genotype='hpv16'``; v2 expects ``genotypes=['hpv16']``.
@@ -175,15 +178,13 @@ PARS_HPV16_TRANSMISSION_ONLY = dict(
 PARS_HPV16 = PARS
 
 
-def _summary_v2_m01(sim, gen_idx, gen_key):
+def _summary_v2_m01(sim, gen_idx):
     """v2-side M01 summary: 3 transmission-only metrics matching
     short_summary_m01.METRIC_KEYS_M01."""
-    import numpy as np
     res = sim.results
-    pop_scale = float(sim.pars.get('pop_scale', 1.0) or 1.0)
-    inf_arr = np.asarray(res['infections'][gen_idx, :], dtype=float)
-    n_inf = float(inf_arr.sum()) * pop_scale
-    prev_arr = np.asarray(res['hpv_prevalence'][gen_idx, :], dtype=float)
+    inf_arr = np.asarray(res['infections_by_genotype'][gen_idx], dtype=float)
+    n_inf = float(inf_arr.sum())
+    prev_arr = np.asarray(res['hpv_prevalence_by_genotype'][gen_idx], dtype=float)
     mean_prev_pct = 100.0 * float(prev_arr.mean())
     total_pop = float(np.asarray(res['n_alive'])[-1])
     return {

--- a/tests/regression/multi_seed_v2.py
+++ b/tests/regression/multi_seed_v2.py
@@ -28,34 +28,67 @@ import hpvsim as hpv
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from baseline_v23 import (  # noqa: E402
     PARS_4GENOTYPE,
+    PARS_HPV16,
+    PARS_HPV16_TRANSMISSION_ONLY,
     _per_genotype_metrics_v2,
     _aggregate_metrics_v2,
+    _summary_v2_m01,
 )
 
 
-DEFAULT_OUT = Path(__file__).resolve().parent / 'v2_seeds.json'
-DEFAULT_GENOTYPES = ('hpv16', 'hpv18', 'hi5', 'ohr')
+DEFAULT_OUT_4GENOTYPE = Path(__file__).resolve().parent / 'v2_seeds_n30.json'
+DEFAULT_OUT_M01 = Path(__file__).resolve().parent / 'v2_m01_seeds_n30.json'
+DEFAULT_OUT_M02 = Path(__file__).resolve().parent / 'v2_m02_seeds_n30.json'
+
+ANCHORS = {
+    'm03_4genotype': dict(
+        pars=PARS_4GENOTYPE,
+        genotypes=('hpv16', 'hpv18', 'hi5', 'ohr'),
+        out=DEFAULT_OUT_4GENOTYPE,
+        mode='m03',
+    ),
+    'm02': dict(
+        pars=PARS_HPV16,
+        genotypes=('hpv16',),
+        out=DEFAULT_OUT_M02,
+        mode='m03',
+    ),
+    'm01': dict(
+        pars=PARS_HPV16_TRANSMISSION_ONLY,
+        genotypes=('hpv16',),
+        out=DEFAULT_OUT_M01,
+        mode='m01',
+    ),
+}
 
 
-def run_seed(seed, genotypes=DEFAULT_GENOTYPES):
-    pars = sc.dcp(PARS_4GENOTYPE)
+def run_seed(seed, anchor='m03_4genotype'):
+    cfg = ANCHORS[anchor]
+    pars = sc.dcp(cfg['pars'])
     pars['rand_seed'] = int(seed)
-    pars['genotypes'] = list(genotypes)
+    pars['genotypes'] = list(cfg['genotypes'])
     sim = hpv.Sim(pars)
     sim.run()
 
-    genotype_map = sim.pars['genotype_map']
-    genotype_pairs = [(i, k) for i, k in sorted(genotype_map.items())]
-
     summary = {}
-    for gen_idx, gen_key in genotype_pairs:
-        per = _per_genotype_metrics_v2(sim, gen_idx, gen_key)
+    if cfg['mode'] == 'm03':
+        genotype_map = sim.pars['genotype_map']
+        genotype_pairs = [(i, k) for i, k in sorted(genotype_map.items())]
+        for gen_idx, gen_key in genotype_pairs:
+            per = _per_genotype_metrics_v2(sim, gen_idx, gen_key)
+            for k, v in per.items():
+                summary[f'{gen_key}.{k}'] = float(v)
+        agg = _aggregate_metrics_v2(sim, genotype_pairs)
+        for k, v in agg.items():
+            summary[f'any.{k}'] = float(v)
+    elif cfg['mode'] == 'm01':
+        genotype_map = sim.pars['genotype_map']
+        gen_idx = next(i for i, k in genotype_map.items() if k == 'hpv16')
+        per = _summary_v2_m01(sim, gen_idx, 'hpv16')
         for k, v in per.items():
-            summary[f'{gen_key}.{k}'] = float(v)
-
-    agg = _aggregate_metrics_v2(sim, genotype_pairs)
-    for k, v in agg.items():
-        summary[f'any.{k}'] = float(v)
+            summary[k] = float(v)
+    else:
+        raise ValueError(f"Unknown anchor mode: {cfg['mode']}")
 
     summary['_seed'] = int(seed)
     if 'n_alive' in sim.results:
@@ -67,33 +100,31 @@ def run_seed(seed, genotypes=DEFAULT_GENOTYPES):
 
 def main(argv=None):
     p = argparse.ArgumentParser()
-    p.add_argument('--n', type=int, default=10)
+    p.add_argument('--anchor', choices=list(ANCHORS), default='m03_4genotype',
+                   help='Anchor to run (m01, m02, or m03_4genotype).')
+    p.add_argument('--n', type=int, default=30)
     p.add_argument('--start-seed', type=int, default=0)
-    p.add_argument('--out', type=Path, default=DEFAULT_OUT)
-    p.add_argument('--genotypes', type=str, default=None,
-                   help='Comma-separated genotype list (default hpv16,hpv18,hi5,ohr)')
+    p.add_argument('--out', type=Path, default=None,
+                   help='Override the default output path for this anchor.')
     args = p.parse_args(argv)
 
-    if args.genotypes:
-        genotypes = tuple(g.strip() for g in args.genotypes.split(','))
-    else:
-        genotypes = DEFAULT_GENOTYPES
-
+    out_path = args.out or ANCHORS[args.anchor]['out']
     seeds = list(range(args.start_seed, args.start_seed + args.n))
     results = []
     t0 = time.time()
     for seed in seeds:
         ts = time.time()
-        s = run_seed(seed, genotypes=genotypes)
+        s = run_seed(seed, anchor=args.anchor)
         dt = time.time() - ts
         results.append(s)
-        print(f'  seed {seed}: done in {dt:.1f}s '
-              f'(any.total HPV infections={s["any.total HPV infections"]:.0f})')
+        diag_key = next(iter(k for k in s if k not in ('_seed', '_total_pop')))
+        print(f'  seed {seed} ({args.anchor}): done in {dt:.1f}s '
+              f'({diag_key}={s[diag_key]:.4g})')
     total = time.time() - t0
-    args.out.parent.mkdir(parents=True, exist_ok=True)
-    with open(args.out, 'w') as f:
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(out_path, 'w') as f:
         json.dump(results, f, indent=2)
-    print(f'Wrote {len(results)} seed summaries to {args.out} in {total:.1f}s')
+    print(f'Wrote {len(results)} seed summaries to {out_path} in {total:.1f}s')
 
 
 if __name__ == '__main__':

--- a/tests/regression/multi_seed_v2.py
+++ b/tests/regression/multi_seed_v2.py
@@ -1,17 +1,18 @@
-"""Multi-seed sweep of the v2.3 4-genotype anchor sim.
+"""Multi-seed sweep of one of the v2.3 anchor sims for M01/M02/M03.
 
-Runs the v2 baseline with N seeds and writes a JSON list of 40-entry
-summary dicts (key layout matches ``short_summary.METRIC_KEYS`` and
-``v3_seeds.json`` produced by ``multi_seed_v3.py``).
+Runs the v2 baseline for the chosen anchor with N seeds and writes a
+JSON list of per-seed summary dicts. The summary key layout matches the
+matching v3 builder (short_summary_m01.METRIC_KEYS_M01 for M01,
+short_summary.METRIC_KEYS via `<g>.<metric>` + `any.<metric>` for M02 / M03).
 
-Reuses ``_per_genotype_metrics_v2`` and ``_aggregate_metrics_v2`` from
-``baseline_v23.py`` — same pop / config / lifetime-mean-age semantics that
-the production v2 baselines use.
+Reuses helpers from ``baseline_v23.py`` — same pop / config /
+lifetime-mean-age semantics that the production v2 baselines use.
 
 Run from a v2.3 env at the repo root:
 
-    "<v2 env>/python.exe" tests/regression/multi_seed_v2.py
-    "<v2 env>/python.exe" tests/regression/multi_seed_v2.py --n 20
+    "<v2 env>/python.exe" tests/regression/multi_seed_v2.py --anchor m03_4genotype --n 30
+    "<v2 env>/python.exe" tests/regression/multi_seed_v2.py --anchor m02 --n 30
+    "<v2 env>/python.exe" tests/regression/multi_seed_v2.py --anchor m01 --n 30
 
 DO NOT run inside the v3 env.
 """
@@ -83,8 +84,10 @@ def run_seed(seed, anchor='m03_4genotype'):
             summary[f'any.{k}'] = float(v)
     elif cfg['mode'] == 'm01':
         genotype_map = sim.pars['genotype_map']
-        gen_idx = next(i for i, k in genotype_map.items() if k == 'hpv16')
-        per = _summary_v2_m01(sim, gen_idx, 'hpv16')
+        gen_idx = next((i for i, k in genotype_map.items() if k == 'hpv16'), None)
+        if gen_idx is None:
+            raise ValueError(f"hpv16 not found in genotype_map: {genotype_map}")
+        per = _summary_v2_m01(sim, gen_idx)
         for k, v in per.items():
             summary[k] = float(v)
     else:

--- a/tests/regression/parity.py
+++ b/tests/regression/parity.py
@@ -1,0 +1,57 @@
+"""Shared parity-gate helper for multi-seed v3-vs-v2 metric comparison.
+
+The z-score formula is
+
+    z = (v3_mean - v2_mean) / sqrt(v2_SE^2 + v3_SE^2)
+
+where SE is the standard error of the mean across seeds (std with ddof=1
+divided by sqrt(n)). A metric fails when |z| >= z_threshold.
+
+Per-seed rows are dicts of {metric_name: value}. Non-metric bookkeeping
+keys (e.g. _seed, _total_pop) should be passed via skip_keys.
+"""
+import math
+
+import numpy as np
+
+
+def _mean_se(rows, key):
+    vals = np.array([float(r[key]) for r in rows if key in r], dtype=float)
+    if vals.size == 0:
+        return None
+    mean = float(vals.mean())
+    se = float(vals.std(ddof=1) / math.sqrt(vals.size)) if vals.size > 1 else 0.0
+    return mean, se
+
+
+def parity_gate(v3_seeds, v2_seeds, z_threshold=3.0, skip_keys=frozenset()):
+    """Return [(metric_name, z)] for metrics exceeding |z| >= z_threshold.
+
+    Args:
+        v3_seeds: list of per-seed summary dicts from the v3 run.
+        v2_seeds: list of per-seed summary dicts from the v2 baseline.
+        z_threshold: failure threshold; metrics with |z| >= threshold fail.
+        skip_keys: metric names to ignore (bookkeeping fields).
+
+    Two degenerate-distribution policies:
+      - both v2 and v3 have zero spread AND exactly equal means → pass.
+      - both have zero spread AND unequal means → fail with z=inf.
+    """
+    metric_keys = sorted((set(v2_seeds[0]) & set(v3_seeds[0])) - skip_keys)
+    failures = []
+    for key in metric_keys:
+        v2_stats = _mean_se(v2_seeds, key)
+        v3_stats = _mean_se(v3_seeds, key)
+        if v2_stats is None or v3_stats is None:
+            continue
+        v2_mean, v2_se = v2_stats
+        v3_mean, v3_se = v3_stats
+        se_combo = math.sqrt(v2_se ** 2 + v3_se ** 2)
+        if se_combo == 0:
+            if v2_mean != v3_mean:
+                failures.append((key, float('inf')))
+            continue
+        z = (v3_mean - v2_mean) / se_combo
+        if abs(z) >= z_threshold:
+            failures.append((key, z))
+    return failures

--- a/tests/regression/short_summary_m01.py
+++ b/tests/regression/short_summary_m01.py
@@ -1,0 +1,29 @@
+"""M01 short-summary builder (transmission-only, no precin/CIN/cancer).
+
+M01 ports only the SIS transmission core; cancer-related metrics from
+the M02/M03 short_summary do not apply here.
+"""
+import numpy as np
+
+
+METRIC_KEYS_M01 = (
+    'total HPV infections',
+    'mean HPV prevalence (%)',
+    'total population',
+)
+
+
+def build_summary_m01(sim, genotype='hpv16'):
+    """Return the 3-entry M01 summary as a flat dict."""
+    res = sim.results[genotype]
+    pop_scale = float(getattr(sim.pars, 'pop_scale', 1.0) or 1.0)
+
+    n_inf = float(np.asarray(res.new_infections).sum()) * pop_scale
+    mean_prev_pct = 100.0 * float(np.asarray(res.prevalence).mean())
+    total_pop = float(np.asarray(sim.results['n_alive'])[-1])
+
+    return {
+        'total HPV infections': n_inf,
+        'mean HPV prevalence (%)': mean_prev_pct,
+        'total population': total_pop,
+    }

--- a/tests/regression/test_parity_helper.py
+++ b/tests/regression/test_parity_helper.py
@@ -1,0 +1,50 @@
+"""Unit tests for the shared parity_gate helper."""
+import math
+import pytest
+
+from tests.regression.parity import parity_gate
+
+
+def _row(seed, **metrics):
+    return {'_seed': seed, **metrics}
+
+
+def test_parity_gate_pass_means_overlap():
+    v2 = [_row(s, m=10.0 + 0.1 * s) for s in range(5)]
+    v3 = [_row(s, m=10.0 + 0.1 * s) for s in range(5)]
+    failures = parity_gate(v3, v2, z_threshold=3.0)
+    assert failures == []
+
+
+def test_parity_gate_fail_large_drift():
+    v2 = [_row(s, m=10.0 + 0.1 * s) for s in range(10)]
+    v3 = [_row(s, m=100.0 + 0.1 * s) for s in range(10)]
+    failures = parity_gate(v3, v2, z_threshold=3.0)
+    assert len(failures) == 1
+    name, z = failures[0]
+    assert name == 'm'
+    assert abs(z) > 3.0
+
+
+def test_parity_gate_skip_keys_ignored():
+    v2 = [_row(s, m=10.0, _total_pop=1e6) for s in range(5)]
+    v3 = [_row(s, m=10.0, _total_pop=2e6) for s in range(5)]
+    failures = parity_gate(v3, v2, z_threshold=3.0,
+                           skip_keys=frozenset({'_total_pop'}))
+    assert failures == []
+
+
+def test_parity_gate_degenerate_distributions_exact_match_passes():
+    v2 = [_row(s, m=10.0) for s in range(5)]
+    v3 = [_row(s, m=10.0) for s in range(5)]
+    failures = parity_gate(v3, v2, z_threshold=3.0)
+    assert failures == []
+
+
+def test_parity_gate_degenerate_distributions_mismatch_fails():
+    v2 = [_row(s, m=10.0) for s in range(5)]
+    v3 = [_row(s, m=11.0) for s in range(5)]
+    failures = parity_gate(v3, v2, z_threshold=3.0)
+    assert len(failures) == 1
+    assert failures[0][0] == 'm'
+    assert math.isinf(failures[0][1])

--- a/tests/regression/test_short_summary_m01.py
+++ b/tests/regression/test_short_summary_m01.py
@@ -1,0 +1,17 @@
+"""Unit test: M01 short summary returns the right keys + plausible values."""
+import pytest
+
+import hpvsim as hpv
+
+from tests.regression.anchor_m01 import make_sim
+from tests.regression.short_summary_m01 import build_summary_m01, METRIC_KEYS_M01
+
+
+def test_build_summary_m01_keys_and_shape():
+    sim = make_sim()
+    sim.run()
+    out = build_summary_m01(sim)
+    assert set(out.keys()) == set(METRIC_KEYS_M01)
+    assert out['total HPV infections'] >= 0
+    assert 0.0 <= out['mean HPV prevalence (%)'] <= 100.0
+    assert out['total population'] > 0

--- a/tests/test_m01_short_summary_parity.py
+++ b/tests/test_m01_short_summary_parity.py
@@ -1,0 +1,65 @@
+"""M01 acceptance gate: multi-seed mean parity vs. v2 HPV16-transmission baseline.
+
+Runs N_V3_SEEDS v3 seeds with the M01 anchor PARS, then gates each
+short-summary metric on
+
+    z = (v3_mean - v2_mean) / sqrt(v2_SE^2 + v3_SE^2)
+
+and fails any metric with |z| > Z_THRESHOLD. The v2 baseline is the
+30-seed sweep at tests/regression/v2_m01_seeds_n30.json (gitignored;
+regenerate via ``multi_seed_v2.py --anchor m01 --n 30`` from a v2 env).
+"""
+import json
+from pathlib import Path
+
+import pytest
+import sciris as sc
+
+import hpvsim as hpv
+
+from tests.regression.anchor_m01 import PARS
+from tests.regression.short_summary_m01 import build_summary_m01
+from tests.regression.parity import parity_gate
+
+
+BASELINE_PATH = Path('tests/regression/v2_m01_seeds_n30.json')
+N_V3_SEEDS = 30
+Z_THRESHOLD = 3.0
+
+_SKIP_KEYS = frozenset({'_seed', '_total_pop'})
+
+
+def _run_v3_seeds(n, start_seed=0):
+    summaries = []
+    for seed in range(start_seed, start_seed + n):
+        pars = sc.dcp(PARS)
+        pars['rand_seed'] = int(seed)
+        sim = hpv.Sim(**pars)
+        sim.run()
+        summaries.append(build_summary_m01(sim))
+    return summaries
+
+
+@pytest.mark.slow
+def test_m01_short_summary_parity():
+    if not BASELINE_PATH.exists():
+        pytest.skip(
+            f'Missing v2 M01 baseline at {BASELINE_PATH}. Regenerate via '
+            f'`python tests/regression/multi_seed_v2.py --anchor m01 --n 30` '
+            f'from a v2 hpvsim env.'
+        )
+    v2_rows = json.loads(BASELINE_PATH.read_text())
+    v3_rows = _run_v3_seeds(N_V3_SEEDS, start_seed=0)
+
+    failures = parity_gate(
+        v3_rows, v2_rows, z_threshold=Z_THRESHOLD, skip_keys=_SKIP_KEYS,
+    )
+
+    if failures:
+        details = '\n'.join(
+            f'  {name:<40} z={z:+.2f}' for name, z in failures
+        )
+        pytest.fail(
+            f'M01 mean parity drift exceeds |z|>{Z_THRESHOLD} on '
+            f'{len(failures)} metrics (v2 n={len(v2_rows)}, v3 n={len(v3_rows)}):\n{details}'
+        )

--- a/tests/test_m02_short_summary_parity.py
+++ b/tests/test_m02_short_summary_parity.py
@@ -1,0 +1,65 @@
+"""M02 acceptance gate: multi-seed mean parity vs. v2 HPV16 baseline.
+
+Runs N_V3_SEEDS v3 seeds with the M02 anchor PARS, then gates each
+short-summary metric on
+
+    z = (v3_mean - v2_mean) / sqrt(v2_SE^2 + v3_SE^2)
+
+and fails any metric with |z| > Z_THRESHOLD. The v2 baseline is the
+30-seed sweep at tests/regression/v2_m02_seeds_n30.json (gitignored;
+regenerate via ``multi_seed_v2.py --anchor m02 --n 30`` from a v2 env).
+"""
+import json
+from pathlib import Path
+
+import pytest
+import sciris as sc
+
+import hpvsim as hpv
+
+from tests.regression.anchor_m02 import PARS, GENOTYPES
+from tests.regression.short_summary import build_summary
+from tests.regression.parity import parity_gate
+
+
+BASELINE_PATH = Path('tests/regression/v2_m02_seeds_n30.json')
+N_V3_SEEDS = 30
+Z_THRESHOLD = 3.0
+
+_SKIP_KEYS = frozenset({'_seed', '_total_pop', 'total population'})
+
+
+def _run_v3_seeds(n, start_seed=0):
+    summaries = []
+    for seed in range(start_seed, start_seed + n):
+        pars = sc.dcp(PARS)
+        pars['rand_seed'] = int(seed)
+        sim = hpv.Sim(**pars)
+        sim.run()
+        summaries.append(build_summary(sim, genotypes=GENOTYPES))
+    return summaries
+
+
+@pytest.mark.slow
+def test_m02_short_summary_parity():
+    if not BASELINE_PATH.exists():
+        pytest.skip(
+            f'Missing v2 M02 baseline at {BASELINE_PATH}. Regenerate via '
+            f'`python tests/regression/multi_seed_v2.py --anchor m02 --n 30` '
+            f'from a v2 hpvsim env.'
+        )
+    v2_rows = json.loads(BASELINE_PATH.read_text())
+    v3_rows = _run_v3_seeds(N_V3_SEEDS, start_seed=0)
+
+    failures = parity_gate(
+        v3_rows, v2_rows, z_threshold=Z_THRESHOLD, skip_keys=_SKIP_KEYS,
+    )
+
+    if failures:
+        details = '\n'.join(
+            f'  {name:<50} z={z:+.2f}' for name, z in failures
+        )
+        pytest.fail(
+            f'M02 mean parity drift exceeds |z|>{Z_THRESHOLD} on '
+            f'{len(failures)} metrics (v2 n={len(v2_rows)}, v3 n={len(v3_rows)}):\n{details}'
+        )

--- a/tests/test_m07_demo_smoke.py
+++ b/tests/test_m07_demo_smoke.py
@@ -1,0 +1,41 @@
+"""Tiny smoke variant of examples/m07_uq_sweep.py so CI catches bit rot.
+
+Uses 1 coverage × 2 seeds. Verifies the make_sim + ss.parallel + ss.MultiSim
++ median pipeline executes and produces non-trivial results — NOT a parity
+gate. Real-shape demo lives in examples/m07_uq_sweep.py.
+"""
+import sciris as sc
+import starsim as ss
+import hpvsim as hpv
+
+
+def _make_tiny_vx_sim(seed, coverage):
+    return hpv.Sim(
+        n_agents=500,
+        location='nigeria',
+        genotypes=[16],
+        start=2010,
+        stop=2013,
+        dt=0.25,
+        rand_seed=int(seed),
+        verbose=0,
+        label=f'coverage={coverage:.0%}|seed={seed}',
+        interventions=[hpv.routine_vx(
+            product='bivalent', prob=float(coverage),
+            age_range=(9, 14), sex='f',
+        )],
+    )
+
+
+def test_demo_pipeline_runs_end_to_end():
+    """sc.parallelize + ss.parallel + ss.MultiSim.median works on hpv.Sim."""
+    iterkwargs = [dict(seed=s, coverage=0.6) for s in range(2)]
+    sims = sc.parallelize(_make_tiny_vx_sim, iterkwargs=iterkwargs)
+    msim = ss.parallel(*sims, verbose=0)
+    sub = ss.MultiSim(list(msim.sims))
+    sub.median()
+    # Median-reduced result has the same shape as each underlying sim.
+    # MultiSim results use flattened keys (hpv16_cum_infections), not nested.
+    cum_inf = sub.results.hpv16_cum_infections
+    assert len(cum_inf) > 0
+    assert float(cum_inf[-1]) >= 0

--- a/tests/test_m07_multisim.py
+++ b/tests/test_m07_multisim.py
@@ -10,7 +10,6 @@ Tiny n_agents and short dur keep each test under ~5 s.
 import numpy as np
 import pytest
 
-import sciris as sc
 import starsim as ss
 import hpvsim as hpv
 
@@ -47,23 +46,32 @@ def test_multisim_median_reduce_shape_and_nonneg():
     """msim.median() exposes median + 10/90 quantile arrays; non-negative for counts."""
     sim = _tiny_sim(rand_seed=0)
     msim = ss.MultiSim(sim, n_runs=5).run(verbose=0)
-    pre_len = len(np.asarray(msim.sims[0].results.hpv16.cum_infections))
+    pre_len = len(msim.sims[0].results.hpv16.cum_infections)
     msim.median()
     # After reduce, msim exposes a single aggregate result with the same
     # time-axis length as each underlying sim. Results are flattened to top-level keys.
     reduced = np.asarray(msim.results.hpv16_cum_infections)
     assert reduced.shape == (pre_len,)
     assert np.all(reduced >= 0), 'cum_infections must be non-negative post-median'
+    low = np.asarray(msim.results.hpv16_cum_infections.low)
+    high = np.asarray(msim.results.hpv16_cum_infections.high)
+    assert low.shape == (pre_len,), f'Expected low.shape {(pre_len,)}, got {low.shape}'
+    assert high.shape == (pre_len,), f'Expected high.shape {(pre_len,)}, got {high.shape}'
+    assert np.all(low >= 0), 'q10 lower bound must be non-negative'
+    assert np.all(high >= low), 'q90 must be >= q10 everywhere'
 
 
 def test_multisim_mean_reduce_smoke():
     """msim.mean() functions (smoke test). Don't use on bounded metrics in production."""
     sim = _tiny_sim(rand_seed=0)
     msim = ss.MultiSim(sim, n_runs=5).run(verbose=0)
+    pre_len = len(msim.sims[0].results.hpv16.cum_infections)
     msim.mean()
     reduced = np.asarray(msim.results.hpv16_cum_infections)
-    assert reduced.shape[0] > 0
+    assert reduced.shape == (pre_len,), f'Expected shape {(pre_len,)}, got {reduced.shape}'
     assert np.isfinite(reduced).all()
+    assert hasattr(msim.results.hpv16_cum_infections, 'low'), 'mean() result must carry .low attribute'
+    assert hasattr(msim.results.hpv16_cum_infections, 'high'), 'mean() result must carry .high attribute'
 
 
 def test_multisim_labels_propagate():

--- a/tests/test_m07_multisim.py
+++ b/tests/test_m07_multisim.py
@@ -1,0 +1,73 @@
+"""Verification tests: ss.MultiSim works with hpv.Sim.
+
+These tests confirm Starsim's MultiSim machinery composes correctly with
+hpv.Sim. They are NOT parity gates against v2 — they pin down behavior
+hpvsim depends on so future Starsim upgrades that change the contract
+break here loudly.
+
+Tiny n_agents and short dur keep each test under ~5 s.
+"""
+import numpy as np
+import pytest
+
+import sciris as sc
+import starsim as ss
+import hpvsim as hpv
+
+
+def _tiny_sim(rand_seed=0, label=None):
+    return hpv.Sim(
+        n_agents=300,
+        location='nigeria',
+        genotypes=[16],
+        start=2000,
+        stop=2003,
+        dt=0.25,
+        rand_seed=rand_seed,
+        verbose=0,
+        label=label,
+    )
+
+
+def test_multisim_n_runs_distinct_seeds():
+    """ss.MultiSim(sim, n_runs=N).run() produces N sims with distinct seeds."""
+    sim = _tiny_sim(rand_seed=0)
+    msim = ss.MultiSim(sim, n_runs=4).run(verbose=0)
+    assert len(msim.sims) == 4
+    seeds = [int(s.pars.rand_seed) for s in msim.sims]
+    assert len(set(seeds)) == 4, f'Expected 4 distinct seeds, got {seeds}'
+    # Every run produced finite total infections.
+    for s in msim.sims:
+        cum_inf = float(s.results.hpv16.cum_infections[-1])
+        assert np.isfinite(cum_inf)
+        assert cum_inf >= 0
+
+
+def test_multisim_median_reduce_shape_and_nonneg():
+    """msim.median() exposes median + 10/90 quantile arrays; non-negative for counts."""
+    sim = _tiny_sim(rand_seed=0)
+    msim = ss.MultiSim(sim, n_runs=5).run(verbose=0)
+    pre_len = len(np.asarray(msim.sims[0].results.hpv16.cum_infections))
+    msim.median()
+    # After reduce, msim exposes a single aggregate result with the same
+    # time-axis length as each underlying sim. Results are flattened to top-level keys.
+    reduced = np.asarray(msim.results.hpv16_cum_infections)
+    assert reduced.shape == (pre_len,)
+    assert np.all(reduced >= 0), 'cum_infections must be non-negative post-median'
+
+
+def test_multisim_mean_reduce_smoke():
+    """msim.mean() functions (smoke test). Don't use on bounded metrics in production."""
+    sim = _tiny_sim(rand_seed=0)
+    msim = ss.MultiSim(sim, n_runs=5).run(verbose=0)
+    msim.mean()
+    reduced = np.asarray(msim.results.hpv16_cum_infections)
+    assert reduced.shape[0] > 0
+    assert np.isfinite(reduced).all()
+
+
+def test_multisim_labels_propagate():
+    """Labels on input sims survive to msim.sims[i].label after run()."""
+    sims = [_tiny_sim(rand_seed=s, label=f'rep-{s}') for s in range(3)]
+    msim = ss.MultiSim(sims).run(verbose=0)
+    assert [s.label for s in msim.sims] == ['rep-0', 'rep-1', 'rep-2']

--- a/tests/test_m07_parallel.py
+++ b/tests/test_m07_parallel.py
@@ -7,10 +7,9 @@ Locks in four properties hpvsim relies on:
   4. copy_inputs=True (sim default) ensures shared module references are
      independent per sim post-construction — the [[feedback_sim_input_copy]]
      discipline reified as a regression test. Module state must be accessed
-     via sim.interventions[...] after construction, not via the original
-     reference.
+     via each sim's own copy (e.g. sim.get_module(name)), not via the
+     original reference.
 """
-import numpy as np
 import pytest
 
 import starsim as ss
@@ -111,3 +110,6 @@ def test_parallel_copy_inputs_independent_after_construction():
     # Post-run, each sim has final state without interference from the other.
     assert float(s1.results.hpv16.cum_infections[-1]) >= 0
     assert float(s2.results.hpv16.cum_infections[-1]) >= 0
+    r1 = float(s1.results.hpv16.cum_infections[-1])
+    r2 = float(s2.results.hpv16.cum_infections[-1])
+    assert r1 != r2, 'Sims with different seeds must not contaminate each other'

--- a/tests/test_m07_parallel.py
+++ b/tests/test_m07_parallel.py
@@ -1,0 +1,113 @@
+"""Verification tests: ss.parallel + hpv.Sim with correct RNG semantics.
+
+Locks in four properties hpvsim relies on:
+  1. Same rand_seed → identical short summaries (CRN guarantee).
+  2. Different rand_seeds → plausibly distinct, plausibly distributed results.
+  3. ss.parallel(inplace=True) (default) populates the original sims.
+  4. copy_inputs=True (sim default) ensures shared module references are
+     independent per sim post-construction — the [[feedback_sim_input_copy]]
+     discipline reified as a regression test. Module state must be accessed
+     via sim.interventions[...] after construction, not via the original
+     reference.
+"""
+import numpy as np
+import pytest
+
+import starsim as ss
+import hpvsim as hpv
+
+
+def _tiny_sim(rand_seed=0, label=None):
+    return hpv.Sim(
+        n_agents=300,
+        location='nigeria',
+        genotypes=[16],
+        start=2000,
+        stop=2003,
+        dt=0.25,
+        rand_seed=rand_seed,
+        verbose=0,
+        label=label,
+    )
+
+
+def _short_summary(sim):
+    """Tiny summary suitable for bit-equality assertions."""
+    return {
+        'cum_inf': float(sim.results.hpv16.cum_infections[-1]),
+        'n_alive': float(sim.results['n_alive'][-1]),
+    }
+
+
+def test_parallel_seed_reproducibility():
+    """Same rand_seed → identical short summary across two ss.parallel calls."""
+    s1 = _tiny_sim(rand_seed=42, label='a')
+    s2 = _tiny_sim(rand_seed=42, label='b')
+    ss.parallel(s1, s2, verbose=0)
+    assert _short_summary(s1) == _short_summary(s2)
+
+
+def test_parallel_seed_separation():
+    """Different rand_seeds → different short summaries (sanity)."""
+    s1 = _tiny_sim(rand_seed=0, label='a')
+    s2 = _tiny_sim(rand_seed=1, label='b')
+    ss.parallel(s1, s2, verbose=0)
+    a = _short_summary(s1)
+    b = _short_summary(s2)
+    # Pin: the two summaries must not be byte-identical. (Theoretically
+    # could be equal by chance — astronomically unlikely for a 300-agent
+    # 3-year run.)
+    assert a != b
+
+
+def test_parallel_inplace_true_default_mutates_originals():
+    """ss.parallel(s1, s2) (default inplace=True) leaves s1/s2 with populated results."""
+    s1 = _tiny_sim(rand_seed=0, label='a')
+    s2 = _tiny_sim(rand_seed=1, label='b')
+    ss.parallel(s1, s2, verbose=0)
+    # Both originals carry results after the call.
+    assert float(s1.results.hpv16.cum_infections[-1]) >= 0
+    assert float(s2.results.hpv16.cum_infections[-1]) >= 0
+
+
+def test_parallel_inplace_false_leaves_originals_unrun():
+    """ss.parallel(inplace=False) preserves originals as unrun."""
+    s1 = _tiny_sim(rand_seed=0, label='a')
+    s2 = _tiny_sim(rand_seed=1, label='b')
+    msim = ss.parallel(s1, s2, verbose=0, inplace=False)
+    # The originals are not run; check that s1.ti is still None (uninitialized).
+    assert s1.ti is None
+    assert s2.ti is None
+    # The MultiSim's internal copies DID run.
+    assert float(msim.sims[0].results.hpv16.cum_infections[-1]) >= 0
+
+
+def test_parallel_copy_inputs_independent_after_construction():
+    """Shared module reference → independent per-sim copies after Sim construction.
+
+    Memory: hpv.Sim deep-copies interventions/analyzers/diseases in __init__.
+    After construction, each sim's diseases are independent, even when
+    initialized from the same reference. ss.parallel may replace modules
+    post-run with fresh copies (ss.parallel creates new sims internally);
+    what matters is that the pre-run modules were distinct.
+    """
+    shared_hpv_list = [hpv.HPV(genotype='hpv16')]
+    s1 = hpv.Sim(
+        n_agents=300, location='nigeria', diseases=shared_hpv_list,
+        start=2000, stop=2003, dt=0.25, rand_seed=0, verbose=0, label='a',
+    )
+    s2 = hpv.Sim(
+        n_agents=300, location='nigeria', diseases=shared_hpv_list,
+        start=2000, stop=2003, dt=0.25, rand_seed=1, verbose=0, label='b',
+    )
+    # After construction, each sim's module is its OWN copy (deep-copy discipline).
+    s1_mod = s1.get_module('hpv16')
+    s2_mod = s2.get_module('hpv16')
+    assert s1_mod is not s2_mod, 'Each Sim must deep-copy its diseases'
+    assert s1_mod is not shared_hpv_list[0], 'Sim must not reuse input module reference'
+    assert s2_mod is not shared_hpv_list[0], 'Sim must not reuse input module reference'
+
+    ss.parallel(s1, s2, verbose=0)
+    # Post-run, each sim has final state without interference from the other.
+    assert float(s1.results.hpv16.cum_infections[-1]) >= 0
+    assert float(s2.results.hpv16.cum_infections[-1]) >= 0


### PR DESCRIPTION
  ## Summary

  - **Verify Starsim's `ss.MultiSim` and `ss.parallel` compose correctly with `hpv.Sim`** — 9 verification tests covering replicate runs, median/mean reduction, label propagation, seed reproducibility,
  `inplace`/`copy_inputs` semantics.
  - **Retrofit M01 and M02 acceptance gates to multi-seed z-score parity** (`|z| < 3` over 30 v3 seeds vs 30 v2 seeds), matching the M03 standard. Adds a shared `parity_gate()` helper in
  `tests/regression/parity.py`.
  - **Ship `examples/m07_uq_sweep.py`** — a 4 × 20 (coverage × seed) routine-vx sweep on the M05 Nigeria 4-genotype anchor, producing a cumulative-cancers-by-coverage plot with median + 10/90 quantile
  bands. Plus a smoke test (`test_m07_demo_smoke.py`) so the demo doesn't bit-rot.

  **Zero new production code under `hpvsim/`.** All deliverables are tests, examples, and docs.

  ## What's NOT in this PR (deliberate scope drops)

  - `hpv.Scenarios` shim, `hpv.Sweep` shim — dropped. Users use Starsim-native `make_sim(seed, scenario)` + `ss.parallel` / `sc.parallelize` directly. Validation repos that import `hpvsim.Scenarios`
  will need a separate post-merge PR per repo, coordinated with Robyn per RACI.

  ## Files

  **New**: 12 files
  - `tests/regression/parity.py` — shared z-score parity helper
  - `tests/regression/short_summary_m01.py`, `anchor_m01.py`, `anchor_m02.py`
  - `tests/test_m07_multisim.py`, `test_m07_parallel.py`, `test_m07_demo_smoke.py`
  - `tests/test_m01_short_summary_parity.py`, `test_m02_short_summary_parity.py`
  - `tests/regression/test_parity_helper.py`, `test_short_summary_m01.py`
  - `examples/m07_uq_sweep.py`

  **Modified**: 5 files
  - `tests/regression/multi_seed_v2.py` (`--anchor m01|m02|m03_4genotype` dispatch)
  - `tests/regression/baseline_v23.py` (M01 PARS + `_summary_v2_m01` builder + `PARS_HPV16` alias)
  - `tests/regression/README.md` (M07 anchors section using canonical milestone naming)
  - `docs/tutorials/tut_running.qmd` (rewritten onto Starsim-native APIs)
  - `MIGRATION_PLAN.md` (M07 sub-task list realignment; status table M5/M6/M7/M8-M10)
  - `.gitignore` (added `*.png` so demo output isn't committed)

  ## Branch + dependency strategy

  - Branched off `m06-test-and-treat-cascade` (rebased onto it 2026-05-28). M06's history includes M05's tip, so the M05 deliverables the demo depends on (`hpv.routine_vx`, `hpv.vx`,
  `anchor_vx_routine`, `products_vx.csv`) are reachable through the M06 base.
  - **Hold as draft against `v3.0-dev`** until M05 and M06 land there. After they merge, this branch either fast-forwards or rebases once more.

  ## Test plan

  - [x] All 9 fast tests pass locally (`test_m07_multisim.py`, `test_m07_parallel.py`, `test_m07_demo_smoke.py`, `test_parity_helper.py`, `test_short_summary_m01.py`)
  - [x] M01 and M02 parity tests SKIP cleanly when their v2 baseline JSONs are absent, with skip messages pointing at the regen command
  - [x] M07 demo runs end-to-end (`python examples/m07_uq_sweep.py` produces `m07_uq_sweep.png`, ~2-3 min for 80 sims)
  - [x] `multi_seed_v2.py` and `baseline_v23.py` are syntax-valid for execution under a v2.3 env (regen path manually verified by `ast.parse`)
  - [ ] **Reviewer to run** (from a v2 hpvsim env): `python tests/regression/multi_seed_v2.py --anchor m01 --n 30` and `--anchor m02 --n 30`. Then re-run the slow parity tests with `pytest -m slow` from
   the v3 env to confirm `|z| < 3` for both new anchors.
  - [ ] **Reviewer to confirm**: the new `examples/m07_uq_sweep.py` demo produces a visually distinct vaccine-impact signal (cumulative cancers drop from ~940 at 0% coverage to ~790 at 90% coverage by
  2060 in local runs — a ~15% reduction, consistent with bivalent vaccine coverage of HPV16/18 only).

  ## Spec + plan

  - Spec: `docs/superpowers/specs/2026-05-27-m07-multisim-design.md`
  - Plan: `docs/superpowers/plans/2026-05-27-m07-multisim.md`

  ## Tracking follow-ups (not gating this PR)

  - Refactor M03/M05 parity tests onto the new `parity_gate()` helper (code dedup, no behavior change).
  - Update validation repos (`hpvsim_methods_manuscript`, `hpvsim_india`, etc.) to drop `hpv.Scenarios` imports.
  - Pre-existing `hpv.MultiSim`/`hpv.parallel` references in `tut_interventions.qmd`, `tut_intro.qmd`, `tut_people.qmd`, and `examples/t05_screen_algorithms.py` — those will break under v3; bundle into
  a small follow-up PR.
  - Audit cross-scenario CRN across truly different parameter values.

  🤖 Generated with [Claude Code](https://claude.com/claude-code)